### PR TITLE
docs: fix .env.example typo in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Be respectful and constructive. This is a hobby-friendly project; we’re here t
 
 1. **Fork and clone** the repo (or clone directly if you have write access).
 2. **Node and pnpm:** Use Node 20 or 22 (see [.nvmrc](.nvmrc); run `nvm use`). Enable pnpm: `corepack enable && pnpm install`.
-3. **Environment:** Copy [.env.exmaple](.env.exmaple) to `.env` and set `DISCORD_TOKEN` and `DISCORD_CLIENT_ID` (see [README](README.md#setting-up-a-discord-bot)).
+3. **Environment:** Copy [.env.example](.env.example) to `.env` and set `DISCORD_TOKEN` and `DISCORD_CLIENT_ID` (see [README](README.md#setting-up-a-discord-bot)).
 4. **Run the app:** `pnpm dev` starts the bot and web dashboard. The dashboard is at http://localhost:5173 and proxies `/api` to the bot.
 
 ## Before you submit

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ After the invite, the bot will appear in your server’s member list (offline un
 In the repo root, copy the sample env and fill in the values you copied:
 
 ```bash
-cp .env.exmaple .env
+cp .env.example .env
 ```
 
 Edit `.env` and set:
@@ -76,7 +76,7 @@ Optional: `DISCORD_GUILD_ID` (a server ID for testing), `HIBIKI_PREFIX` (default
 git clone https://github.com/phyberapex/hibiki.git
 cd hibiki
 corepack enable && pnpm install
-cp .env.exmaple .env   # set DISCORD_TOKEN and DISCORD_CLIENT_ID (see above)
+cp .env.example .env   # set DISCORD_TOKEN and DISCORD_CLIENT_ID (see above)
 pnpm dev
 ```
 
@@ -99,7 +99,7 @@ Dashboard is bundled and served by the bot at the same port (e.g. http://localho
 ### Run with Compose (local or server)
 
 ```bash
-cp .env.exmaple .env   # set DISCORD_TOKEN and DISCORD_CLIENT_ID
+cp .env.example .env   # set DISCORD_TOKEN and DISCORD_CLIENT_ID
 mkdir -p storage
 docker compose up -d
 ```

--- a/apps/bot/README.md
+++ b/apps/bot/README.md
@@ -39,7 +39,7 @@ pnpm install
 
 ### Environment variables
 
-Copy `.env.exmaple` to `.env` at the workspace root (or use your shell env) with:
+Copy `.env.example` to `.env` at the workspace root (or use your shell env) with:
 
 ```bash
 DISCORD_TOKEN=...
@@ -123,7 +123,7 @@ When running in Docker, mount `./storage` to a volume so uploads + snapshots sur
 
 From the **repo root**:
 
-1. Copy `.env.exmaple` to `.env` and set `DISCORD_TOKEN` and `DISCORD_CLIENT_ID`.
+1. Copy `.env.example` to `.env` and set `DISCORD_TOKEN` and `DISCORD_CLIENT_ID`.
 2. Create a `storage` directory (or let Docker create it when the volume mounts):
    ```bash
    mkdir -p storage

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,7 @@ You need a Discord application and bot token before running Hibiki. Follow these
 {: .steps}
 
 ```bash
-cp .env.exmaple .env
+cp .env.example .env
 # Edit .env and set:
 # DISCORD_TOKEN=your_bot_token
 # DISCORD_CLIENT_ID=your_application_id
@@ -50,7 +50,7 @@ After the Discord bot is set up, install dependencies and start the bot and dash
 git clone https://github.com/phyberapex/hibiki.git
 cd hibiki
 corepack enable && pnpm install
-cp .env.exmaple .env   # set DISCORD_TOKEN and DISCORD_CLIENT_ID
+cp .env.example .env   # set DISCORD_TOKEN and DISCORD_CLIENT_ID
 pnpm dev
 ```
 


### PR DESCRIPTION
## Summary

The env file is correctly named `.env.example` but all documentation referenced it as `.env.exmaple` (missing the letter "l").

## Changes

Fixed typo in:
- README.md (3 occurrences)
- CONTRIBUTING.md (1 occurrence)
- docs/index.md (2 occurrences)
- apps/bot/README.md (2 occurrences)

---

*El Psy Kongroo* 🫡