### PR TITLE
chore(pnpm): migrate onlyBuiltDependencies to pnpm-workspace.yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,18 +87,5 @@
     "vite-plugin-vue-devtools": "^8.0.5",
     "vitest": "^4.0.0",
     "vue-tsc": "^3.2.4"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@discordjs/opus",
-      "@snazzah/davey",
-      "electron",
-      "electron-winstaller",
-      "esbuild",
-      "fs-xattr",
-      "lzma-native",
-      "macos-alias",
-      "unrs-resolver"
-    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,10 @@
 allowBuilds:
   '@discordjs/opus': true
+  '@snazzah/davey': true
   electron: true
   electron-winstaller: true
   esbuild: true
+  fs-xattr: true
+  lzma-native: true
+  macos-alias: true
   unrs-resolver: true


### PR DESCRIPTION
## Summary
- pnpm 11 no longer reads build-approval config from package.json's `pnpm` field (silently ignored with a warning on every install)
- Moves the 4 entries missing from `pnpm-workspace.yaml`'s `allowBuilds` (`@snazzah/davey`, `fs-xattr`, `lzma-native`, `macos-alias`) over from the now-dead `package.json` `pnpm.onlyBuiltDependencies` field, and removes that field

## Test plan
- [x] `pnpm install` runs clean with no build-config warning