### PR TITLE
docs: Vision-to-Vibe domain context and ADR

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,12 @@
+# Hibiki — Domain Context
+
+Single-context repo (see `agent-docs/domain.md` for how this file is meant to be used). Architectural decisions live in `agent-docs/adr/`.
+
+## Glossary
+
+- **Scene** — a soundboard template (Music, Ambience, Effects categories) stored in `scenes.json`. Not a runtime object; playback state lives in `GuildAudioManager`. See `CLAUDE.md`.
+- **Sound Library** — the GM's own uploaded sound files (`SoundFile`, `src/sound/sound.types.ts`), organized by category (`music` | `effects` | `ambience`). Distinct from the **Registry**.
+- **Registry** — the separate curated catalog of community-shared scene bundles (`RegistryEntry`, `registry/`), installable into a user's own scenes via `installFromRegistry`. Registry entries carry their own `tags: string[]`.
+- **Sound Tags** — free-form `tags: string[]` on a `SoundFile` (Sound Library), authored manually by the GM per sound. Used for Vibe Matching (see `agent-docs/adr/0001-vision-to-vibe-matching.md`). **Do not confuse with Registry tags** — same field name, different domain object, different purpose (Registry tags describe a shared community scene; Sound Tags describe one of the GM's own files).
+- **Vibe Tags** — free-form tags extracted from an uploaded image by a vision-capable model, describing mood, setting, weather, or time-of-day.
+- **Vibe Match** — a ranked Sound Library entry (Music or Ambience only) whose Sound Tags overlap with a set of Vibe Tags.

--- a/agent-docs/adr/0001-vision-to-vibe-matching.md
+++ b/agent-docs/adr/0001-vision-to-vibe-matching.md
@@ -1,0 +1,32 @@
+# 0001. Vision-to-Vibe matching: Sound Tags on the Sound Library, Claude as MVP vision provider
+
+## Status
+
+Accepted
+
+## Context
+
+Issue #319 proposes letting a GM drop an image (a battle map, mood board, character art) into Hibiki and get back suggested Music/Ambience sounds matching the image's "vibe," instead of manually browsing/searching their library mid-session.
+
+The issue's original proposal assumed matching could rank "the closest matches already in the user's sound library... existing tags." That assumption doesn't hold: `SoundFile` (`src/sound/sound.types.ts`) — the type for a GM's own uploaded music/ambience/effects — has no `tags` field. The only `tags: string[]` in the codebase belongs to `RegistryEntry` (`frontend/src/api/registry.ts`), the separate curated community scene catalog (`registry/scenes/...`), not a GM's personal library.
+
+This ADR records the decisions reached (via `/triage` + `/grilling` on #319) to close that gap and scope the MVP.
+
+## Decision
+
+- **Sound Tags**: add an optional `tags: string[]` field to `SoundFile`. Free-form strings, authored manually by the GM, edited inline per row in the existing sound-library list UI. No auto-tagging of existing audio in this MVP — a sparsely-tagged library gets a UI nudge, not an AI assist.
+- **Vibe Tags**: a new `vision` IPC domain (`analyzeImageVibe(imagePath)`) calls a vision-capable model to extract free-form mood/setting/weather/time-of-day tags plus a short description from an uploaded image.
+- **Provider**: Claude (Anthropic) only for MVP. Support for additional vision providers is tracked as a separate follow-up issue, not bundled into #319.
+- **Matching**: case-insensitive exact/substring overlap count between Vibe Tags and each `SoundFile`'s Sound Tags, ranked descending, top ~5 surfaced per category.
+- **Scope**: Music and Ambience categories only. Effects (one-shot triggered sounds) are excluded — a static image doesn't imply a situational trigger the way it implies a mood loop.
+- **Entry point & flow**: a scene-level button in the scene editor (visible regardless of which category tab is active), augmenting the currently open scene. No new-scene-creation flow.
+- **Results UI**: shows the extracted Vibe Tags/description first, then two independently-actionable ranked lists (top Music matches, top Ambience matches) — no bulk-accept, no auto-add of the top result.
+- **Settings & consent**: new API key field, env var `HIBIKI_VISION_API_KEY` (falls back like `DISCORD_TOKEN` today), stored in `app-config.json`. A toggle defaulted off; the scene-editor entry point stays hidden/disabled until a key is set *and* the toggle is switched on.
+- **Explicitly out of scope**: generative-audio (the issue's own "stretch" goal), Effects-category matching, auto-tagging of existing audio, multi-provider support.
+
+## Consequences
+
+- Adding `tags` to `SoundFile` is a small additive schema change (default `[]`), no migration needed for existing sound files.
+- The feature is "you get out what you tag in" at launch — value is gated on GMs manually tagging their library, which may limit day-one usefulness for large untagged libraries. Accepted as a reasonable MVP tradeoff over building an auto-tagging pipeline.
+- Introduces Hibiki's first third-party network dependency for a *creative* feature (vision analysis), separate from the existing Discord API dependency. Opt-in and clearly disclosed per the consent UX above.
+- Locking the MVP to one vision provider (Claude) means the `vision` IPC domain's internal interface should stay provider-agnostic enough that a second provider (tracked separately) doesn't require reshaping the public API.


### PR DESCRIPTION
## Summary

- Adds `CONTEXT.md` (the repo's first) with a domain glossary — notably clarifying **Sound Library** vs **Registry**, and **Sound Tags** vs **Vibe Tags**, since the two `tags: string[]` fields involved look identical but mean different things.
- Adds `agent-docs/adr/0001-vision-to-vibe-matching.md` recording the scope decisions reached while triaging/grilling #319 (Vision-to-Vibe Alchemy): adding `tags` to `SoundFile`, Claude as the sole MVP vision provider, Music+Ambience-only matching, entry point/result UX, and settings/consent shape.

This exists so the eventual #319 implementation (and any future related work) has a fixed reference instead of re-deriving these decisions from the issue thread.

## Test plan

- [ ] Docs-only change — no code affected. `pnpm lint`/`pnpm test` not required but can be run if desired.