### PR TITLE
feat(ui): rhythmic status pulses with accessibility toggles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,6 +241,20 @@ The project is transitioning from a Docker-based monorepo to an Electron app. Se
 - **Build before E2E** — E2E tests launch the built app, not dev mode.
 - **Audio streaming is chunked IPC** — High-volume data; use the existing `audio:chunk` pattern, not single IPC calls.
 
+## Agent skills
+
+### Issue tracker
+
+Issues and specs live in GitHub Issues (PhyberApex/hibiki), managed via the `gh` CLI. See `agent-docs/issue-tracker.md`.
+
+### Triage labels
+
+Default canonical labels (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`), used as-is. See `agent-docs/triage-labels.md`.
+
+### Domain docs
+
+Single-context layout — `CONTEXT.md` + `agent-docs/adr/` at the repo root (neither exists yet). See `agent-docs/domain.md`.
+
 ## References
 
 - **README.md** — User-facing setup, download, quick start

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,11 +6,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **Hibiki (響)** is a desktop audio companion for Discord, built as an Electron app. It plays music, ambience, and sound effects in Discord voice channels from a desktop UI. Originally designed for Dungeons & Dragons (background music, ambient soundscapes, one-shot effects) but works for any server.
 
-**Current state:** The project is mid-migration from a monorepo (with separate `apps/bot` and `apps/web`) to a unified Electron app. The old structure has been deleted (see git status). The new `app/` package is the single application.
+**Current state:** The project has migrated from a monorepo (separate `apps/bot` and `apps/web`) to a unified Electron app. The repo root is the single application package (`electron/`, `src/`, `frontend/`), with `e2e/` as a separate workspace for Playwright tests.
 
 ## Common Commands
 
-**IMPORTANT:** Always run `nvm use` before executing any pnpm commands to activate the correct Node.js version (24.14.0).
+**IMPORTANT:** Always run `nvm use` before executing any pnpm commands to activate the Node.js version pinned in `.nvmrc`.
 
 All commands run from the **repo root**:
 
@@ -44,17 +44,18 @@ pnpm package            # Create unpacked app only (for testing)
 
 ```bash
 # Backend tests (Jest)
-cd app && pnpm run test:backend           # All backend tests
-cd app && pnpm run test:watch             # Watch mode
+pnpm test:backend                         # All backend tests
+pnpm test:watch                           # Watch mode
+npx jest --config jest.config.js <file>   # Single test file
 
 # Frontend tests (Vitest)
-cd app && pnpm run test:frontend          # All frontend tests
-cd app/frontend && vitest run <file>      # Single test file
+pnpm test:frontend                        # All frontend tests
+cd frontend && npx vitest run <file>      # Single test file
 
 # Coverage
-pnpm run test:coverage                    # Both backend + frontend
-cd app && pnpm run test:coverage:backend  # Backend only
-cd app && pnpm run test:coverage:frontend # Frontend only
+pnpm test:coverage                        # Both backend + frontend
+pnpm test:coverage:backend                # Backend only
+pnpm test:coverage:frontend               # Frontend only
 ```
 
 ## Architecture
@@ -62,7 +63,7 @@ cd app && pnpm run test:coverage:frontend # Frontend only
 ### Electron Structure
 
 ```text
-app/
+.                      # Repo root = the application package
 ├── electron/          # Electron main process
 │   ├── main.js        # Entry point: boots backend, creates window, IPC handlers
 │   ├── preload.js     # Bridge: exposes safe IPC to renderer
@@ -81,8 +82,11 @@ app/
 │   └── src/
 │       ├── api/       # IPC wrappers (typed frontend API calling backend)
 │       ├── audio/     # Web Audio capture (AudioWorklet for browser streaming)
-│       ├── stores/    # Pinia stores (player state, guild directory)
+│       ├── composables/ # Reusable Vue composition helpers
+│       ├── stores/    # Pinia stores (player state, guild directory, accessibility)
 │       └── views/     # Pages (Welcome, Scenes, Browser, Media, Settings)
+├── e2e/               # Playwright E2E workspace (separate package)
+├── registry/          # Community scene registry (index + schema)
 ├── web-dist/          # Built frontend (Vite output)
 └── dist/              # Compiled backend (tsc output)
 ```
@@ -182,16 +186,16 @@ The scene is a **template**, not a runtime object. Playback state lives in `Guil
 
 ### Backend (Jest)
 
-- Config: `app/jest.config.js`
-- Test files: `app/src/**/*.spec.ts`
-- Run: `cd app && pnpm run test:backend`
-- Watch: `cd app && pnpm run test:watch`
+- Config: `jest.config.js`
+- Test files: `src/**/*.spec.ts`
+- Run: `pnpm test:backend`
+- Watch: `pnpm test:watch`
 
 ### Frontend (Vitest)
 
-- Config: `app/frontend/vitest.config.ts`
-- Test files: `app/frontend/src/**/*.spec.ts`
-- Run: `cd app && pnpm run test:frontend`
+- Config: `frontend/vitest.config.ts`
+- Test files: `frontend/src/**/*.{spec,test}.ts`
+- Run: `pnpm test:frontend`
 
 ### E2E (Playwright)
 
@@ -203,14 +207,14 @@ The scene is a **template**, not a runtime object. Playback state lives in `Guil
 
 ## Migration Context
 
-The project is transitioning from a Docker-based monorepo to an Electron app. See `docs/electron-migration-plan.md` for the full migration plan (phases 1-5). **Current status:** Phases 1-3 mostly complete (permissions and slash commands removed, repo flattened to `app/` + `e2e/`, Electron shell added).
+The project is transitioning from a Docker-based monorepo to an Electron app. See `docs/electron-migration-plan.md` for the full migration plan (phases 1-5). **Current status:** Phases 1-3 mostly complete (permissions and slash commands removed, repo flattened to a single root package + `e2e/`, Electron shell added).
 
 **What was removed:**
 - NestJS backend (replaced with plain TypeScript services in `src/`)
 - HTTP API (replaced with IPC)
 - Docker (Dockerfile, docker-compose)
 - Permission system and slash commands (app-only control now)
-- Monorepo `apps/bot` and `apps/web` (merged into `app/`)
+- Monorepo `apps/bot` and `apps/web` (merged into the root package)
 
 **Key differences from old structure:**
 - No HTTP server; all communication is IPC.
@@ -258,7 +262,7 @@ Single-context layout — `CONTEXT.md` + `agent-docs/adr/` at the repo root (nei
 ## References
 
 - **README.md** — User-facing setup, download, quick start
-- **app/README.md** — Architecture details, local dev instructions
+- **frontend/README.md** — Renderer (Vue) architecture, local dev instructions
 - **CONTRIBUTING.md** — Setup, lint/test requirements, PR workflow
 - **docs/electron-migration-plan.md** — Full migration roadmap
 - **e2e/README.md** — E2E test setup, Electron + Playwright compatibility

--- a/agent-docs/domain.md
+++ b/agent-docs/domain.md
@@ -1,0 +1,38 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`agent-docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/agent-docs/adr/` for context-scoped decisions.
+
+  `docs/` in this repo is the public Jekyll site (GitHub Pages, deployed from `/docs`), so ADRs live under `agent-docs/adr/` instead of `docs/adr/` to avoid getting published.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (this repo):
+
+```
+/
+├── CONTEXT.md
+├── agent-docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/agent-docs/issue-tracker.md
+++ b/agent-docs/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and specs for this repo live as GitHub issues (PhyberApex/hibiki). Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/agent-docs/triage-labels.md
+++ b/agent-docs/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| --------------------------- | --------------------- | ----------------------------------------- |
+| `needs-triage`              | `needs-triage`         | Maintainer needs to evaluate this issue  |
+| `needs-info`                | `needs-info`           | Waiting on reporter for more information |
+| `ready-for-agent`           | `ready-for-agent`      | Fully specified, ready for an AFK agent  |
+| `ready-for-human`           | `ready-for-human`      | Requires human implementation            |
+| `wontfix`                   | `wontfix`              | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/frontend/src/App.spec.ts
+++ b/frontend/src/App.spec.ts
@@ -3,8 +3,14 @@ import { createPinia } from 'pinia'
 import { describe, expect, it, vi } from 'vitest'
 import { createMemoryHistory, createRouter } from 'vue-router'
 import App from './App.vue'
+import { usePlayerStore } from './stores/player'
 import AboutView from './views/AboutView.vue'
 import MediaManagementView from './views/MediaManagementView.vue'
+
+vi.mock('@/api/config', () => ({
+  fetchAccessibilitySettings: vi.fn().mockResolvedValue({ luminancePulses: true, reduceMotion: null }),
+  updateAccessibilitySettings: vi.fn().mockResolvedValue(undefined),
+}))
 
 vi.mock('@/api/player', () => ({
   fetchPlayerState: vi.fn().mockResolvedValue([]),
@@ -190,5 +196,117 @@ describe('app', () => {
     })
     await flushPromises()
     expect(wrapper.find('.bot-status').text()).toContain('Disconnected')
+  })
+
+  it('loads accessibility settings on mount', async () => {
+    const { fetchAccessibilitySettings } = await import('@/api/config')
+    vi.mocked(fetchAccessibilitySettings).mockClear()
+    await router.push('/scenes')
+    await router.isReady()
+    mount(App, {
+      global: {
+        plugins: [createPinia(), router],
+      },
+    })
+    await flushPromises()
+    expect(fetchAccessibilitySettings).toHaveBeenCalled()
+  })
+
+  it('pulses the bot status sharply while disconnected', async () => {
+    const { fetchBotStatus } = await import('@/api/player')
+    vi.mocked(fetchBotStatus).mockResolvedValue({ ready: false })
+    await router.push('/scenes')
+    await router.isReady()
+    const wrapper = mount(App, {
+      global: {
+        plugins: [createPinia(), router],
+      },
+    })
+    await flushPromises()
+    const status = wrapper.find('.bot-status')
+    expect(status.classes()).toContain('pulse')
+    expect(status.classes()).toContain('pulse-alert')
+    expect(status.classes()).not.toContain('pulse-steady')
+  })
+
+  it('shows a steady glow on the bot status while connected', async () => {
+    const { fetchBotStatus } = await import('@/api/player')
+    vi.mocked(fetchBotStatus).mockResolvedValue({ ready: true, userTag: 'Bot#0' })
+    await router.push('/scenes')
+    await router.isReady()
+    const wrapper = mount(App, {
+      global: {
+        plugins: [createPinia(), router],
+      },
+    })
+    await flushPromises()
+    const status = wrapper.find('.bot-status')
+    expect(status.classes()).toContain('pulse-steady')
+    expect(status.classes()).not.toContain('pulse-alert')
+  })
+
+  it('pulses the bot status at a busy rate while reconnecting', async () => {
+    const { fetchBotStatus, reconnectBot } = await import('@/api/player')
+    vi.mocked(fetchBotStatus).mockResolvedValue({ ready: false })
+    let releaseReconnect: () => void = () => {}
+    vi.mocked(reconnectBot).mockReturnValue(new Promise<void>((resolve) => {
+      releaseReconnect = resolve
+    }))
+    await router.push('/scenes')
+    await router.isReady()
+    const pinia = createPinia()
+    const wrapper = mount(App, {
+      global: {
+        plugins: [pinia, router],
+      },
+    })
+    await flushPromises()
+    const player = usePlayerStore(pinia)
+    const reconnecting = player.doReconnect()
+    await flushPromises()
+    expect(wrapper.find('.bot-status').classes()).toContain('pulse-busy')
+    vi.mocked(fetchBotStatus).mockResolvedValue({ ready: true, userTag: 'Bot#0' })
+    releaseReconnect()
+    await reconnecting
+    await flushPromises()
+    expect(wrapper.find('.bot-status').classes()).toContain('pulse-steady')
+  })
+
+  it('glows the connected channel dot and pulses a channel while joining', async () => {
+    const { fetchPlayerState, fetchBotStatus, fetchGuildDirectory, joinChannel } = await import('@/api/player')
+    vi.mocked(fetchPlayerState).mockResolvedValue([
+      { guildId: 'g1', connectedChannelId: 'ch1', isIdle: true, track: null, source: 'live' as const },
+    ])
+    vi.mocked(fetchBotStatus).mockResolvedValue({ ready: true, userTag: 'Bot#0' })
+    vi.mocked(fetchGuildDirectory).mockResolvedValue([
+      {
+        guildId: 'g1',
+        guildName: 'Test Guild',
+        iconUrl: null,
+        channels: [{ id: 'ch1', name: 'General' }, { id: 'ch2', name: 'Tavern' }],
+      },
+    ])
+    let releaseJoin: () => void = () => {}
+    vi.mocked(joinChannel).mockReturnValue(new Promise<void>((resolve) => {
+      releaseJoin = resolve
+    }))
+    await router.push('/scenes')
+    await router.isReady()
+    const wrapper = mount(App, {
+      global: {
+        plugins: [createPinia(), router],
+      },
+    })
+    await flushPromises()
+    const dots = wrapper.findAll('.channel-dot')
+    expect(dots[0]!.classes()).toContain('pulse-steady')
+    expect(dots[1]!.classes()).not.toContain('pulse')
+
+    await wrapper.findAll('.channel-item')[1]!.trigger('click')
+    await flushPromises()
+    expect(wrapper.findAll('.channel-dot')[1]!.classes()).toContain('pulse-busy')
+    releaseJoin()
+    await flushPromises()
+    expect(wrapper.findAll('.channel-dot')[1]!.classes()).not.toContain('pulse-busy')
   })
 })

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted } from 'vue'
 import { RouterLink, RouterView, useRoute } from 'vue-router'
+import { useAccessibilityStore } from '@/stores/accessibility'
 import { usePlayerStore } from '@/stores/player'
 
 declare const __APP_VERSION__: string
@@ -8,6 +9,7 @@ const appVersion = typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : '0
 
 const route = useRoute()
 const player = usePlayerStore()
+const accessibility = useAccessibilityStore()
 let pollTimer: ReturnType<typeof setInterval> | null = null
 
 const tabs = [
@@ -41,6 +43,7 @@ function startPollingWhenDisconnected() {
 }
 
 onMounted(() => {
+  accessibility.load()
   player.loadState().then(() => {
     if (player.botStatus?.ready)
       player.loadDirectory()
@@ -60,6 +63,21 @@ const connectedGuild = computed(() =>
   player.directory.find(g => g.guildId === player.connectedGuildId) ?? null,
 )
 const isWelcome = computed(() => route.path === '/')
+
+const botStatusPulse = computed(() => {
+  if (player.reconnecting)
+    return 'pulse-busy'
+  return player.botStatus?.ready ? 'pulse-steady' : 'pulse-alert'
+})
+
+function channelDotPulse(guildId: string, channelId: string): string[] {
+  const isSelected = player.guildId === guildId && player.channelId === channelId
+  if (player.channelJoinBusy && isSelected)
+    return ['pulse', 'pulse-busy']
+  if (player.connectedGuildId === guildId && player.channelId === channelId)
+    return ['pulse', 'pulse-steady']
+  return []
+}
 </script>
 
 <template>
@@ -104,7 +122,11 @@ const isWelcome = computed(() => route.path === '/')
               :title="ch.name"
               @click="player.selectChannel(guild.guildId, ch.id)"
             >
-              <span class="channel-dot" aria-hidden="true" />
+              <span
+                class="channel-dot"
+                :class="channelDotPulse(guild.guildId, ch.id)"
+                aria-hidden="true"
+              />
               {{ ch.name }}
             </button>
           </div>
@@ -145,8 +167,8 @@ const isWelcome = computed(() => route.path === '/')
 
       <div class="sidebar-status">
         <span
-          class="bot-status"
-          :class="[player.botStatus?.ready ? 'bot-status-connected' : 'bot-status-disconnected']"
+          class="bot-status pulse"
+          :class="[player.botStatus?.ready ? 'bot-status-connected' : 'bot-status-disconnected', botStatusPulse]"
           :title="player.botStatus?.ready ? `Connected as ${player.botStatus?.userTag ?? 'bot'}` : 'Discord bot not connected'"
         >
           <span class="bot-status-dot" aria-hidden="true" />
@@ -324,6 +346,11 @@ const isWelcome = computed(() => route.path === '/')
   opacity: 1;
 }
 
+.channel-dot.pulse {
+  --pulse-color: var(--color-accent);
+  --pulse-spread: 6px;
+}
+
 .channel-dot {
   width: 0.35rem;
   height: 0.35rem;
@@ -462,6 +489,7 @@ const isWelcome = computed(() => route.path === '/')
 }
 
 .bot-status-connected {
+  --pulse-color: var(--color-live);
   background: var(--color-success-muted);
   color: var(--color-live);
   border-color: var(--color-live);
@@ -479,6 +507,7 @@ const isWelcome = computed(() => route.path === '/')
 }
 
 .bot-status-disconnected {
+  --pulse-color: var(--color-error);
   background: var(--color-error-muted);
   color: var(--color-error);
   border-color: var(--color-error);

--- a/frontend/src/api/config.test.ts
+++ b/frontend/src/api/config.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  fetchAccessibilitySettings,
   fetchDiscordConfig,
   fetchStoragePath,
   listBookmarks,
@@ -8,6 +9,7 @@ import {
   saveFileDialog,
   selectFolder,
   selectStorageFolder,
+  updateAccessibilitySettings,
   updateDiscordToken,
   updateStoragePath,
 } from './config'
@@ -132,6 +134,29 @@ describe('config API', () => {
       domain: 'config',
       method: 'setBookmarks',
       args: [bookmarks],
+    })
+  })
+
+  it('fetchAccessibilitySettings uses apiCall', async () => {
+    const settings = { luminancePulses: false, reduceMotion: true }
+    mockInvoke.mockResolvedValue(settings)
+    const result = await fetchAccessibilitySettings()
+    expect(mockInvoke).toHaveBeenCalledWith('api', {
+      domain: 'config',
+      method: 'getAccessibility',
+      args: [],
+    })
+    expect(result).toEqual(settings)
+  })
+
+  it('updateAccessibilitySettings uses apiCall', async () => {
+    mockInvoke.mockResolvedValue(undefined)
+    const settings = { luminancePulses: true, reduceMotion: null }
+    await updateAccessibilitySettings(settings)
+    expect(mockInvoke).toHaveBeenCalledWith('api', {
+      domain: 'config',
+      method: 'setAccessibility',
+      args: [settings],
     })
   })
 

--- a/frontend/src/api/config.ts
+++ b/frontend/src/api/config.ts
@@ -8,6 +8,12 @@ export interface StorageConfig {
   path: string | null
 }
 
+export interface AccessibilitySettings {
+  luminancePulses: boolean
+  /** `null` follows the OS `prefers-reduced-motion` setting. */
+  reduceMotion: boolean | null
+}
+
 function requireElectron(): void {
   if (!useElectronApi())
     throw new Error('Hibiki runs as an Electron app. Open it via pnpm run electron.')
@@ -31,6 +37,16 @@ export function fetchStoragePath(): Promise<StorageConfig> {
 export function updateStoragePath(path: string): Promise<void> {
   requireElectron()
   return apiCall<void>('config', 'setStoragePath', [path])
+}
+
+export function fetchAccessibilitySettings(): Promise<AccessibilitySettings> {
+  requireElectron()
+  return apiCall<AccessibilitySettings>('config', 'getAccessibility', [])
+}
+
+export function updateAccessibilitySettings(settings: AccessibilitySettings): Promise<void> {
+  requireElectron()
+  return apiCall<void>('config', 'setAccessibility', [settings])
 }
 
 export async function selectStorageFolder(): Promise<string | null> {

--- a/frontend/src/assets/base.css
+++ b/frontend/src/assets/base.css
@@ -75,16 +75,30 @@ input {
   outline-offset: 2px;
 }
 
-/* Respect reduced-motion preference */
+/*
+ * Respect reduced-motion preference. The Settings "Reduce motion" toggle
+ * (stores/accessibility.ts) layers on top via root classes: `reduce-motion`
+ * applies the same reset regardless of the OS, `allow-motion` marks an
+ * explicit opt-out that lets the OS preference be overridden.
+ */
 @media (prefers-reduced-motion: reduce) {
-  *,
-  *::before,
-  *::after {
+  :root:not(.allow-motion) *,
+  :root:not(.allow-motion) *::before,
+  :root:not(.allow-motion) *::after {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
     scroll-behavior: auto !important;
   }
+}
+
+.reduce-motion *,
+.reduce-motion *::before,
+.reduce-motion *::after {
+  animation-duration: 0.01ms !important;
+  animation-iteration-count: 1 !important;
+  transition-duration: 0.01ms !important;
+  scroll-behavior: auto !important;
 }
 
 /* ── Shared button styles ── */

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -1,4 +1,5 @@
 @import './base.css';
+@import './pulse.css';
 
 #app {
   min-height: 100vh;

--- a/frontend/src/assets/pulse.css
+++ b/frontend/src/assets/pulse.css
@@ -1,0 +1,75 @@
+/*
+ * Pulse layer — status indicators glow in rhythm so that rate and sharpness
+ * carry meaning alongside color:
+ *
+ *   pulse-steady   idle / connected       static soft glow
+ *   pulse-breathe  ambience looping       slow, soft breathing
+ *   pulse-busy     connecting / joining   medium, even
+ *   pulse-alert    error / disconnected   fast, sharp attack
+ *   pulse-flash    one-shot effect fired  single bright burst
+ *
+ * Set --pulse-color on the element to tint the glow. The `pulses-off` and
+ * `reduce-motion` root classes (see stores/accessibility.ts) switch the layer
+ * off, leaving indicators in their plain color-only appearance.
+ */
+
+.pulse {
+  --pulse-color: currentColor;
+  --pulse-spread: 8px;
+  --pulse-glow: color-mix(in srgb, var(--pulse-color) 55%, transparent);
+  --pulse-glow-soft: color-mix(in srgb, var(--pulse-color) 28%, transparent);
+}
+
+.pulse-steady {
+  box-shadow: 0 0 var(--pulse-spread) 0 var(--pulse-glow-soft);
+}
+
+.pulse-breathe {
+  animation: pulse-glow 4s ease-in-out infinite;
+}
+
+.pulse-busy {
+  animation: pulse-glow 1.4s ease-in-out infinite;
+}
+
+.pulse-alert {
+  animation: pulse-sharp 0.9s cubic-bezier(0.1, 0.8, 0.3, 1) infinite;
+}
+
+.pulse-flash {
+  animation: pulse-flash 0.5s ease-out 1 both;
+}
+
+@keyframes pulse-glow {
+  0%, 100% {
+    box-shadow: 0 0 0 0 transparent;
+  }
+  50% {
+    box-shadow: 0 0 var(--pulse-spread) calc(var(--pulse-spread) / 4) var(--pulse-glow);
+  }
+}
+
+@keyframes pulse-sharp {
+  0% {
+    box-shadow: 0 0 var(--pulse-spread) calc(var(--pulse-spread) / 2) var(--pulse-glow);
+  }
+  100% {
+    box-shadow: 0 0 0 0 transparent;
+  }
+}
+
+@keyframes pulse-flash {
+  0% {
+    box-shadow: 0 0 calc(var(--pulse-spread) * 2) calc(var(--pulse-spread) / 2) var(--pulse-color);
+    filter: brightness(1.5);
+  }
+  100% {
+    box-shadow: 0 0 0 0 transparent;
+    filter: brightness(1);
+  }
+}
+
+.pulses-off .pulse {
+  animation: none;
+  box-shadow: none;
+}

--- a/frontend/src/composables/useFlashSet.spec.ts
+++ b/frontend/src/composables/useFlashSet.spec.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useFlashSet } from './useFlashSet'
+
+describe('useFlashSet', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('marks an id as flashing for the configured duration', () => {
+    const flash = useFlashSet(500)
+    expect(flash.has('a')).toBe(false)
+    flash.trigger('a')
+    expect(flash.has('a')).toBe(true)
+    vi.advanceTimersByTime(499)
+    expect(flash.has('a')).toBe(true)
+    vi.advanceTimersByTime(1)
+    expect(flash.has('a')).toBe(false)
+  })
+
+  it('tracks ids independently', () => {
+    const flash = useFlashSet(500)
+    flash.trigger('a')
+    vi.advanceTimersByTime(300)
+    flash.trigger('b')
+    vi.advanceTimersByTime(200)
+    expect(flash.has('a')).toBe(false)
+    expect(flash.has('b')).toBe(true)
+  })
+
+  it('extends the flash when re-triggered while active', () => {
+    const flash = useFlashSet(500)
+    flash.trigger('a')
+    vi.advanceTimersByTime(400)
+    flash.trigger('a')
+    vi.advanceTimersByTime(400)
+    expect(flash.has('a')).toBe(true)
+    vi.advanceTimersByTime(100)
+    expect(flash.has('a')).toBe(false)
+  })
+})

--- a/frontend/src/composables/useFlashSet.ts
+++ b/frontend/src/composables/useFlashSet.ts
@@ -1,0 +1,27 @@
+import { ref } from 'vue'
+
+/**
+ * Reactive set of ids that are "flashing": each id stays active for
+ * `durationMs` after its latest trigger, then drops out on its own.
+ */
+export function useFlashSet(durationMs = 500) {
+  const active = ref(new Set<string>())
+  const timers = new Map<string, ReturnType<typeof setTimeout>>()
+
+  function trigger(id: string) {
+    const pending = timers.get(id)
+    if (pending)
+      clearTimeout(pending)
+    active.value.add(id)
+    timers.set(id, setTimeout(() => {
+      active.value.delete(id)
+      timers.delete(id)
+    }, durationMs))
+  }
+
+  function has(id: string): boolean {
+    return active.value.has(id)
+  }
+
+  return { has, trigger }
+}

--- a/frontend/src/stores/accessibility.spec.ts
+++ b/frontend/src/stores/accessibility.spec.ts
@@ -1,0 +1,142 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import { useAccessibilityStore } from './accessibility'
+
+vi.mock('@/api/config', () => ({
+  fetchAccessibilitySettings: vi.fn().mockResolvedValue({ luminancePulses: true, reduceMotion: null }),
+  updateAccessibilitySettings: vi.fn().mockResolvedValue(undefined),
+}))
+
+type MediaListener = (event: { matches: boolean }) => void
+
+function stubMatchMedia(matches: boolean) {
+  const listeners: MediaListener[] = []
+  const mql = {
+    matches,
+    addEventListener: vi.fn((_: string, cb: MediaListener) => listeners.push(cb)),
+    removeEventListener: vi.fn(),
+  }
+  window.matchMedia = vi.fn().mockReturnValue(mql) as unknown as typeof window.matchMedia
+  return {
+    mql,
+    fire(next: boolean) {
+      mql.matches = next
+      listeners.forEach(cb => cb({ matches: next }))
+    },
+  }
+}
+
+describe('accessibility store', () => {
+  let fetchAccessibilitySettings: ReturnType<typeof vi.fn>
+  let updateAccessibilitySettings: ReturnType<typeof vi.fn>
+
+  beforeEach(async () => {
+    setActivePinia(createPinia())
+    const api = await import('@/api/config')
+    fetchAccessibilitySettings = vi.mocked(api.fetchAccessibilitySettings)
+    updateAccessibilitySettings = vi.mocked(api.updateAccessibilitySettings)
+    vi.clearAllMocks()
+    document.documentElement.className = ''
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    delete (window as { matchMedia?: unknown }).matchMedia
+  })
+
+  it('defaults to pulses on and reduce motion following the OS', () => {
+    stubMatchMedia(false)
+    const store = useAccessibilityStore()
+    expect(store.luminancePulses).toBe(true)
+    expect(store.reduceMotionOverride).toBeNull()
+    expect(store.followsSystemMotion).toBe(true)
+    expect(store.reduceMotion).toBe(false)
+  })
+
+  it('reads the OS prefers-reduced-motion value and tracks changes', () => {
+    const media = stubMatchMedia(true)
+    const store = useAccessibilityStore()
+    expect(store.reduceMotion).toBe(true)
+    media.fire(false)
+    expect(store.reduceMotion).toBe(false)
+  })
+
+  it('works without matchMedia support', () => {
+    const store = useAccessibilityStore()
+    expect(store.reduceMotion).toBe(false)
+  })
+
+  it('lets the user override reduce motion in either direction', async () => {
+    const media = stubMatchMedia(true)
+    const store = useAccessibilityStore()
+    await store.setReduceMotion(false)
+    expect(store.reduceMotion).toBe(false)
+    expect(store.followsSystemMotion).toBe(false)
+    expect(updateAccessibilitySettings).toHaveBeenLastCalledWith({ luminancePulses: true, reduceMotion: false })
+
+    media.fire(false)
+    await store.setReduceMotion(true)
+    expect(store.reduceMotion).toBe(true)
+    expect(updateAccessibilitySettings).toHaveBeenLastCalledWith({ luminancePulses: true, reduceMotion: true })
+
+    await store.setReduceMotion(null)
+    expect(store.followsSystemMotion).toBe(true)
+    expect(store.reduceMotion).toBe(false)
+    expect(updateAccessibilitySettings).toHaveBeenLastCalledWith({ luminancePulses: true, reduceMotion: null })
+  })
+
+  it('persists the luminance pulse toggle', async () => {
+    stubMatchMedia(false)
+    const store = useAccessibilityStore()
+    await store.setLuminancePulses(false)
+    expect(store.luminancePulses).toBe(false)
+    expect(updateAccessibilitySettings).toHaveBeenCalledWith({ luminancePulses: false, reduceMotion: null })
+  })
+
+  it('loads persisted settings', async () => {
+    stubMatchMedia(false)
+    fetchAccessibilitySettings.mockResolvedValueOnce({ luminancePulses: false, reduceMotion: true })
+    const store = useAccessibilityStore()
+    await store.load()
+    expect(store.luminancePulses).toBe(false)
+    expect(store.reduceMotionOverride).toBe(true)
+    expect(store.reduceMotion).toBe(true)
+  })
+
+  it('keeps defaults when loading fails', async () => {
+    stubMatchMedia(false)
+    fetchAccessibilitySettings.mockRejectedValueOnce(new Error('no electron'))
+    const store = useAccessibilityStore()
+    await store.load()
+    expect(store.luminancePulses).toBe(true)
+    expect(store.reduceMotionOverride).toBeNull()
+  })
+
+  it('mirrors effective state onto the document root as classes', async () => {
+    const media = stubMatchMedia(false)
+    const store = useAccessibilityStore()
+    await nextTick()
+    const root = document.documentElement.classList
+    expect(root.contains('pulses-off')).toBe(false)
+    expect(root.contains('reduce-motion')).toBe(false)
+
+    await store.setLuminancePulses(false)
+    await nextTick()
+    expect(root.contains('pulses-off')).toBe(true)
+
+    media.fire(true)
+    await nextTick()
+    expect(root.contains('reduce-motion')).toBe(true)
+
+    await store.setReduceMotion(false)
+    await nextTick()
+    expect(root.contains('reduce-motion')).toBe(false)
+    expect(root.contains('allow-motion')).toBe(true)
+
+    await store.setReduceMotion(null)
+    await nextTick()
+    expect(root.contains('allow-motion')).toBe(false)
+    expect(root.contains('reduce-motion')).toBe(true)
+  })
+})

--- a/frontend/src/stores/accessibility.ts
+++ b/frontend/src/stores/accessibility.ts
@@ -1,0 +1,72 @@
+import { defineStore } from 'pinia'
+import { computed, ref, watchEffect } from 'vue'
+import { fetchAccessibilitySettings, updateAccessibilitySettings } from '@/api/config'
+
+const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)'
+
+function watchSystemReducedMotion(onChange: (matches: boolean) => void): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function')
+    return false
+  const media = window.matchMedia(REDUCED_MOTION_QUERY)
+  media.addEventListener('change', event => onChange(event.matches))
+  return media.matches
+}
+
+export const useAccessibilityStore = defineStore('accessibility', () => {
+  const luminancePulses = ref(true)
+  const reduceMotionOverride = ref<boolean | null>(null)
+  const systemReducesMotion = ref(watchSystemReducedMotion((matches) => {
+    systemReducesMotion.value = matches
+  }))
+
+  const followsSystemMotion = computed(() => reduceMotionOverride.value === null)
+  const reduceMotion = computed(() => reduceMotionOverride.value ?? systemReducesMotion.value)
+
+  if (typeof document !== 'undefined') {
+    watchEffect(() => {
+      const root = document.documentElement.classList
+      root.toggle('pulses-off', !luminancePulses.value)
+      root.toggle('reduce-motion', reduceMotion.value)
+      root.toggle('allow-motion', reduceMotionOverride.value === false)
+    })
+  }
+
+  async function load() {
+    try {
+      const settings = await fetchAccessibilitySettings()
+      luminancePulses.value = settings.luminancePulses
+      reduceMotionOverride.value = settings.reduceMotion
+    }
+    catch {
+      // Expected when running outside Electron (e.g. tests or Vite dev)
+    }
+  }
+
+  function persist() {
+    return updateAccessibilitySettings({
+      luminancePulses: luminancePulses.value,
+      reduceMotion: reduceMotionOverride.value,
+    })
+  }
+
+  async function setLuminancePulses(enabled: boolean) {
+    luminancePulses.value = enabled
+    await persist()
+  }
+
+  async function setReduceMotion(override: boolean | null) {
+    reduceMotionOverride.value = override
+    await persist()
+  }
+
+  return {
+    luminancePulses,
+    reduceMotionOverride,
+    systemReducesMotion,
+    followsSystemMotion,
+    reduceMotion,
+    load,
+    setLuminancePulses,
+    setReduceMotion,
+  }
+})

--- a/frontend/src/views/SceneView.spec.ts
+++ b/frontend/src/views/SceneView.spec.ts
@@ -1,0 +1,135 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { createPinia } from 'pinia'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createMemoryHistory, createRouter } from 'vue-router'
+import SceneView from './SceneView.vue'
+
+vi.mock('@/api/scenes', () => ({
+  listScenes: vi.fn().mockResolvedValue([]),
+  getScene: vi.fn(),
+  saveScene: vi.fn().mockResolvedValue(undefined),
+  deleteScene: vi.fn().mockResolvedValue(undefined),
+  exportScene: vi.fn().mockResolvedValue(undefined),
+  importScene: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@/api/sounds', () => ({
+  listAmbience: vi.fn().mockResolvedValue([{ id: 'amb-1', name: 'Rain', filename: 'rain.mp3' }]),
+  listMusic: vi.fn().mockResolvedValue([]),
+  listEffects: vi.fn().mockResolvedValue([{ id: 'fx-1', name: 'Thunder', filename: 'thunder.mp3' }]),
+  soundStreamUrl: vi.fn((type: string, id: string) => `hibiki://sound/${type}/${id}`),
+}))
+
+vi.mock('@/api/audio-stream', () => ({
+  sendAudioChunk: vi.fn(),
+  sendEffectChunk: vi.fn(),
+  startAudioStream: vi.fn().mockResolvedValue(undefined),
+  startEffectStream: vi.fn().mockResolvedValue(undefined),
+  stopAudioStream: vi.fn().mockResolvedValue(undefined),
+  stopEffectStream: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@/api/config', () => ({
+  openFileDialog: vi.fn().mockResolvedValue(null),
+  saveFileDialog: vi.fn().mockResolvedValue(null),
+}))
+
+vi.mock('@/audio/browser-audio-capture', () => ({
+  captureFromAudioElement: vi.fn().mockResolvedValue({ stop: vi.fn() }),
+}))
+
+const scene = {
+  id: 's1',
+  name: 'Storm',
+  ambience: [{ soundId: 'amb-1', soundName: 'Rain', volume: 80, enabled: true }],
+  music: [],
+  effects: [{ soundId: 'fx-1', soundName: 'Thunder' }],
+}
+
+const router = createRouter({
+  history: createMemoryHistory(),
+  routes: [
+    { path: '/scenes', name: 'scenes', component: SceneView },
+    { path: '/scenes/:id', name: 'scene', component: SceneView },
+    { path: '/media', name: 'media', component: () => Promise.resolve({ template: '<div>Media</div>' }) },
+  ],
+})
+
+const mediaProto = HTMLMediaElement.prototype
+const originalMedia = {
+  load: mediaProto.load,
+  play: mediaProto.play,
+  pause: mediaProto.pause,
+}
+
+function stubMediaElement() {
+  Object.defineProperty(mediaProto, 'load', {
+    configurable: true,
+    value(this: HTMLMediaElement) {
+      queueMicrotask(() => this.dispatchEvent(new Event('canplaythrough')))
+    },
+  })
+  Object.defineProperty(mediaProto, 'play', { configurable: true, value: vi.fn().mockResolvedValue(undefined) })
+  Object.defineProperty(mediaProto, 'pause', { configurable: true, value: vi.fn() })
+}
+
+async function mountScene() {
+  await router.push('/scenes/s1')
+  await router.isReady()
+  const wrapper = mount(SceneView, {
+    global: {
+      plugins: [createPinia(), router],
+      stubs: { RegistryBrowser: true, ResolveSoundDialog: true },
+    },
+  })
+  await flushPromises()
+  return wrapper
+}
+
+const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+describe('sceneView pulses', () => {
+  beforeAll(stubMediaElement)
+
+  beforeEach(async () => {
+    const { getScene } = await import('@/api/scenes')
+    vi.mocked(getScene).mockResolvedValue(JSON.parse(JSON.stringify(scene)))
+  })
+
+  afterAll(() => {
+    Object.defineProperty(mediaProto, 'load', { configurable: true, value: originalMedia.load })
+    Object.defineProperty(mediaProto, 'play', { configurable: true, value: originalMedia.play })
+    Object.defineProperty(mediaProto, 'pause', { configurable: true, value: originalMedia.pause })
+  })
+
+  it('renders the scene without any pulses while idle', async () => {
+    const wrapper = await mountScene()
+    expect(wrapper.find('.detail-title').text()).toBe('Storm')
+    expect(wrapper.find('.sound-card-ambience').classes()).not.toContain('pulse')
+    expect(wrapper.find('.effect-card').classes()).not.toContain('pulse')
+    expect(wrapper.find('.scene-playback-bar').classes()).not.toContain('pulse-flash')
+  })
+
+  it('flashes an effect card briefly when the effect fires', async () => {
+    const wrapper = await mountScene()
+    await wrapper.find('.effect-trigger').trigger('click')
+    const card = wrapper.find('.effect-card')
+    expect(card.classes()).toContain('pulse')
+    expect(card.classes()).toContain('pulse-flash')
+    await wait(650)
+    expect(wrapper.find('.effect-card').classes()).not.toContain('pulse-flash')
+  })
+
+  it('breathes on looping ambience while the scene plays and flashes the playback bar on transition', async () => {
+    const wrapper = await mountScene()
+    await wrapper.find('.btn-play-local').trigger('click')
+    await flushPromises()
+    expect(wrapper.find('.sound-card-ambience').classes()).toContain('pulse')
+    expect(wrapper.find('.sound-card-ambience').classes()).toContain('pulse-breathe')
+    expect(wrapper.find('.scene-playback-bar').classes()).toContain('pulse-flash')
+
+    await wrapper.find('.btn-stop-scene').trigger('click')
+    await flushPromises()
+    expect(wrapper.find('.sound-card-ambience').classes()).not.toContain('pulse-breathe')
+  })
+})

--- a/frontend/src/views/SceneView.vue
+++ b/frontend/src/views/SceneView.vue
@@ -20,6 +20,7 @@ import {
 } from '@/audio/browser-audio-capture'
 import RegistryBrowser from '@/components/RegistryBrowser.vue'
 import ResolveSoundDialog from '@/components/ResolveSoundDialog.vue'
+import { useFlashSet } from '@/composables/useFlashSet'
 import { usePlayerStore } from '@/stores/player'
 
 const route = useRoute()
@@ -48,6 +49,10 @@ const effectAudioEl = createAudioEl()
 const ambienceAudioEls = new Map<string, HTMLAudioElement>()
 const captureSessions = new Map<string, CaptureSession>()
 const ambienceTimers = new Map<string, ReturnType<typeof setTimeout>>()
+const playingAmbienceIds = ref(new Set<string>())
+const effectFlash = useFlashSet()
+const sceneTransitionFlash = useFlashSet()
+const SCENE_START_FLASH = 'start'
 
 function createAudioEl(): HTMLAudioElement {
   const el = new Audio()
@@ -198,6 +203,7 @@ function toggleAmbience(item: SceneItem) {
 }
 
 function stopAmbience(soundId: string) {
+  playingAmbienceIds.value.delete(soundId)
   const timer = ambienceTimers.get(soundId)
   if (timer != null) {
     clearTimeout(timer)
@@ -219,6 +225,7 @@ function stopAmbience(soundId: string) {
 }
 
 function stopAmbienceLocal(soundId: string) {
+  playingAmbienceIds.value.delete(soundId)
   const timer = ambienceTimers.get(soundId)
   if (timer != null) {
     clearTimeout(timer)
@@ -272,6 +279,7 @@ async function playAmbience(item: SceneItem) {
     }
 
     await el.play()
+    playingAmbienceIds.value.add(item.soundId)
   }
   catch (e) {
     console.error('[scene] playAmbience failed:', e)
@@ -305,6 +313,7 @@ async function playAmbienceLocal(item: SceneItem) {
       }
     }
     await el.play()
+    playingAmbienceIds.value.add(item.soundId)
   }
   catch (e) {
     console.error('[scene] playAmbienceLocal failed:', e)
@@ -375,6 +384,7 @@ function stopMusicLocal() {
 }
 
 function playEffectLocal(item: SceneItem) {
+  effectFlash.trigger(item.soundId)
   const el = effectAudioEl
   el.src = soundStreamUrl('effects', item.soundId)
   el.volume = (item.volume ?? 80) / 100 * (globalVolume.value / 100)
@@ -385,6 +395,7 @@ function playEffectLocal(item: SceneItem) {
 async function playEffect(item: SceneItem) {
   if (!guildId.value || !isJoined.value)
     return
+  effectFlash.trigger(item.soundId)
   try {
     const el = effectAudioEl
     const streamId = `effect-${item.soundId}`
@@ -444,6 +455,7 @@ async function playSceneLocal() {
     return
   stopScene()
   scenePlayingLocal.value = true
+  sceneTransitionFlash.trigger(SCENE_START_FLASH)
   try {
     for (const item of scene.value.ambience.filter(a => a.enabled))
       await playAmbienceLocal(item)
@@ -487,6 +499,7 @@ async function playScene() {
     return
   stopSceneLocal()
   player.scenePlaying = true
+  sceneTransitionFlash.trigger(SCENE_START_FLASH)
   try {
     for (const item of scene.value.ambience.filter(a => a.enabled))
       await playAmbience(item)
@@ -789,7 +802,11 @@ watch(sceneId, (newId, oldId) => {
         {{ exportImportMessage.text }}
       </p>
 
-      <div v-if="scene" class="scene-playback-bar">
+      <div
+        v-if="scene"
+        class="scene-playback-bar"
+        :class="{ 'pulse pulse-flash': sceneTransitionFlash.has(SCENE_START_FLASH) }"
+      >
         <label class="global-volume">
           <span class="volume-icon" aria-hidden="true">🔊</span>
           <input
@@ -861,6 +878,7 @@ watch(sceneId, (newId, oldId) => {
               v-for="item in scene.ambience"
               :key="item.soundId"
               class="sound-card sound-card-ambience"
+              :class="{ 'pulse pulse-breathe': playingAmbienceIds.has(item.soundId) }"
             >
               <div class="sound-card-row">
                 <div class="sound-card-info">
@@ -1066,7 +1084,10 @@ watch(sceneId, (newId, oldId) => {
               v-for="item in scene.effects"
               :key="item.soundId"
               class="effect-card"
-              :class="{ 'effect-card-missing': isSoundMissing('effects', item.soundId) }"
+              :class="{
+                'effect-card-missing': isSoundMissing('effects', item.soundId),
+                'pulse pulse-flash': effectFlash.has(item.soundId),
+              }"
             >
               <button
                 type="button"
@@ -1330,6 +1351,7 @@ watch(sceneId, (newId, oldId) => {
 /* ── Playback bar ── */
 
 .scene-playback-bar {
+  --pulse-color: var(--color-accent);
   display: flex;
   align-items: center;
   gap: 1rem;
@@ -1501,6 +1523,7 @@ watch(sceneId, (newId, oldId) => {
 }
 
 .sound-card-ambience {
+  --pulse-color: var(--color-ambience);
   flex-direction: column;
   align-items: stretch;
   gap: 0.35rem;
@@ -1676,6 +1699,7 @@ watch(sceneId, (newId, oldId) => {
 }
 
 .effect-card {
+  --pulse-color: var(--color-effects);
   position: relative;
   display: flex;
   flex-direction: column;

--- a/frontend/src/views/SettingsView.spec.ts
+++ b/frontend/src/views/SettingsView.spec.ts
@@ -1,6 +1,7 @@
 import { flushPromises, mount } from '@vue/test-utils'
 import { createPinia } from 'pinia'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAccessibilityStore } from '@/stores/accessibility'
 import SettingsView from './SettingsView.vue'
 
 vi.mock('@/api/config', () => ({
@@ -9,7 +10,17 @@ vi.mock('@/api/config', () => ({
   selectStorageFolder: vi.fn(),
   updateDiscordToken: vi.fn().mockResolvedValue({ tokenConfigured: true }),
   updateStoragePath: vi.fn().mockResolvedValue(undefined),
+  fetchAccessibilitySettings: vi.fn().mockResolvedValue({ luminancePulses: true, reduceMotion: null }),
+  updateAccessibilitySettings: vi.fn().mockResolvedValue(undefined),
 }))
+
+function stubMatchMedia(matches: boolean) {
+  window.matchMedia = vi.fn().mockReturnValue({
+    matches,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }) as unknown as typeof window.matchMedia
+}
 
 describe('settingsView', () => {
   it('renders Settings heading', async () => {
@@ -35,5 +46,79 @@ describe('settingsView', () => {
     await flushPromises()
     const headings = wrapper.findAll('h2')
     expect(headings.some(h => h.text() === 'Storage location')).toBe(true)
+  })
+
+  describe('accessibility section', () => {
+    beforeEach(() => {
+      vi.clearAllMocks()
+    })
+
+    afterEach(() => {
+      delete (window as { matchMedia?: unknown }).matchMedia
+    })
+
+    it('renders the Accessibility section with both toggles on their defaults', async () => {
+      stubMatchMedia(false)
+      const wrapper = mount(SettingsView, {
+        global: { plugins: [createPinia()] },
+      })
+      await flushPromises()
+      const headings = wrapper.findAll('h2')
+      expect(headings.some(h => h.text() === 'Accessibility')).toBe(true)
+      const pulses = wrapper.find<HTMLInputElement>('#luminance-pulses')
+      const reduceMotion = wrapper.find<HTMLInputElement>('#reduce-motion')
+      expect(pulses.element.checked).toBe(true)
+      expect(reduceMotion.element.checked).toBe(false)
+      expect(wrapper.find('.motion-source').text()).toContain('system')
+      expect(wrapper.find('.btn-motion-reset').exists()).toBe(false)
+    })
+
+    it('reduce motion defaults to the OS preference', async () => {
+      stubMatchMedia(true)
+      const wrapper = mount(SettingsView, {
+        global: { plugins: [createPinia()] },
+      })
+      await flushPromises()
+      expect(wrapper.find<HTMLInputElement>('#reduce-motion').element.checked).toBe(true)
+    })
+
+    it('persists turning luminance pulses off', async () => {
+      stubMatchMedia(false)
+      const { updateAccessibilitySettings } = await import('@/api/config')
+      const wrapper = mount(SettingsView, {
+        global: { plugins: [createPinia()] },
+      })
+      await flushPromises()
+      await wrapper.find('#luminance-pulses').setValue(false)
+      await flushPromises()
+      expect(updateAccessibilitySettings).toHaveBeenCalledWith({ luminancePulses: false, reduceMotion: null })
+    })
+
+    it('overrides reduce motion in either direction and can return to the system setting', async () => {
+      stubMatchMedia(true)
+      const { updateAccessibilitySettings } = await import('@/api/config')
+      const pinia = createPinia()
+      const wrapper = mount(SettingsView, {
+        global: { plugins: [pinia] },
+      })
+      await flushPromises()
+      const store = useAccessibilityStore(pinia)
+
+      await wrapper.find('#reduce-motion').setValue(false)
+      await flushPromises()
+      expect(updateAccessibilitySettings).toHaveBeenLastCalledWith({ luminancePulses: true, reduceMotion: false })
+      expect(store.reduceMotion).toBe(false)
+      expect(wrapper.find('.btn-motion-reset').exists()).toBe(true)
+
+      await wrapper.find('#reduce-motion').setValue(true)
+      await flushPromises()
+      expect(updateAccessibilitySettings).toHaveBeenLastCalledWith({ luminancePulses: true, reduceMotion: true })
+
+      await wrapper.find('.btn-motion-reset').trigger('click')
+      await flushPromises()
+      expect(updateAccessibilitySettings).toHaveBeenLastCalledWith({ luminancePulses: true, reduceMotion: null })
+      expect(store.followsSystemMotion).toBe(true)
+      expect(wrapper.find<HTMLInputElement>('#reduce-motion').element.checked).toBe(true)
+    })
   })
 })

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -7,9 +7,11 @@ import {
   updateDiscordToken,
   updateStoragePath,
 } from '@/api/config'
+import { useAccessibilityStore } from '@/stores/accessibility'
 import { usePlayerStore } from '@/stores/player'
 
 const player = usePlayerStore()
+const accessibility = useAccessibilityStore()
 const discordConfig = ref<{ tokenConfigured: boolean } | null>(null)
 const tokenInput = ref('')
 const saving = ref(false)
@@ -18,6 +20,8 @@ const message = ref<{ type: 'success' | 'error', text: string } | null>(null)
 const storagePath = ref<string | null>(null)
 const savingStorage = ref(false)
 const storageMessage = ref<{ type: 'success' | 'error', text: string } | null>(null)
+
+const accessibilityMessage = ref<{ type: 'success' | 'error', text: string } | null>(null)
 
 async function load() {
   try {
@@ -102,6 +106,30 @@ async function clearStoragePath() {
   finally {
     savingStorage.value = false
   }
+}
+
+async function persistAccessibility(update: () => Promise<void>) {
+  accessibilityMessage.value = null
+  try {
+    await update()
+  }
+  catch (e) {
+    accessibilityMessage.value = { type: 'error', text: e instanceof Error ? e.message : 'Could not save accessibility settings.' }
+  }
+}
+
+function onLuminancePulsesChange(event: Event) {
+  const enabled = (event.target as HTMLInputElement).checked
+  persistAccessibility(() => accessibility.setLuminancePulses(enabled))
+}
+
+function onReduceMotionChange(event: Event) {
+  const enabled = (event.target as HTMLInputElement).checked
+  persistAccessibility(() => accessibility.setReduceMotion(enabled))
+}
+
+function useSystemMotion() {
+  persistAccessibility(() => accessibility.setReduceMotion(null))
 }
 
 onMounted(load)
@@ -230,6 +258,65 @@ onMounted(load)
         {{ storageMessage.text }}
       </p>
     </section>
+
+    <hr class="divider">
+
+    <section class="section">
+      <div class="section-header">
+        <h2 class="section-title">
+          Accessibility
+        </h2>
+      </div>
+      <p class="section-desc">
+        Status indicators glow in rhythm so you can catch changes from the corner of your eye — a slow breath while ambience loops, a sharp pulse when disconnected, a flash when an effect fires.
+      </p>
+      <div class="toggle-list">
+        <div class="toggle-row">
+          <input
+            id="luminance-pulses"
+            type="checkbox"
+            class="toggle-input"
+            :checked="accessibility.luminancePulses"
+            @change="onLuminancePulsesChange"
+          >
+          <div class="toggle-text">
+            <label for="luminance-pulses" class="toggle-title">Status pulses</label>
+            <span class="toggle-desc">Turn off to show status with color only — no glow or rhythm.</span>
+          </div>
+        </div>
+        <div class="toggle-row">
+          <input
+            id="reduce-motion"
+            type="checkbox"
+            class="toggle-input"
+            :checked="accessibility.reduceMotion"
+            @change="onReduceMotionChange"
+          >
+          <div class="toggle-text">
+            <label for="reduce-motion" class="toggle-title">Reduce motion</label>
+            <span class="toggle-desc">Stops pulses and other animations throughout the app.</span>
+            <span class="toggle-desc motion-source">
+              <template v-if="accessibility.followsSystemMotion">
+                Following your system preference ({{ accessibility.systemReducesMotion ? 'on' : 'off' }}).
+              </template>
+              <template v-else>
+                Overriding your system preference.
+                <button type="button" class="btn-motion-reset" @click="useSystemMotion">
+                  Use system setting
+                </button>
+              </template>
+            </span>
+          </div>
+        </div>
+      </div>
+      <p
+        v-if="accessibilityMessage"
+        class="status-message settings-message"
+        :class="[accessibilityMessage.type === 'success' ? 'status-message-success' : 'status-message-error']"
+      >
+        {{ accessibilityMessage.text }}
+      </p>
+    </section>
   </div>
 </template>
 
@@ -331,6 +418,68 @@ onMounted(load)
 .input-readonly {
   color: var(--color-text-muted);
   cursor: default;
+}
+
+/* ── Toggles ── */
+
+.toggle-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.toggle-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.75rem 0.85rem;
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  transition: border-color var(--transition);
+}
+
+.toggle-row:hover {
+  border-color: var(--color-border-focus);
+}
+
+.toggle-input {
+  margin: 0.2rem 0 0;
+  accent-color: var(--color-accent);
+  flex-shrink: 0;
+}
+
+.toggle-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.toggle-title {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--color-text);
+  cursor: pointer;
+}
+
+.toggle-desc {
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+  line-height: 1.45;
+}
+
+.btn-motion-reset {
+  padding: 0;
+  font-size: inherit;
+  color: var(--color-accent);
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.btn-motion-reset:hover {
+  text-decoration: underline;
 }
 
 /* ── Buttons ── */

--- a/src/bootstrap-embedded.ts
+++ b/src/bootstrap-embedded.ts
@@ -1,9 +1,11 @@
 import type { VoiceBasedChannel } from 'discord.js'
+import type { AccessibilitySettings } from './config/accessibility-settings'
 import type { SoundCategory } from './sound/sound.types'
 import { mkdir } from 'node:fs/promises'
 import { dirname } from 'node:path'
 import { generateDependencyReport } from '@discordjs/voice'
 import { getConfig } from './config'
+import { normalizeAccessibilitySettings, parseAccessibilitySettings } from './config/accessibility-settings'
 import { createDiscordClient } from './discord/discord-client'
 import { createAppConfig } from './persistence'
 import { createPlayer } from './player/player'
@@ -62,6 +64,8 @@ export interface EmbeddedApi {
     setStoragePath: (path: string) => Promise<void>
     getBookmarks: () => Promise<{ name: string, url: string, favicon?: string }[]>
     setBookmarks: (bookmarks: { name: string, url: string, favicon?: string }[]) => Promise<void>
+    getAccessibility: () => Promise<AccessibilitySettings>
+    setAccessibility: (settings: AccessibilitySettings) => Promise<void>
   }
   sounds: {
     listMusic: () => ReturnType<ReturnType<typeof createSoundLibrary>['list']>
@@ -175,6 +179,10 @@ export async function getEmbeddedApp(): Promise<EmbeddedApp> {
       },
       setBookmarks: async (bookmarks: { name: string, url: string, favicon?: string }[]) => {
         await appConfig.set('bookmarks', JSON.stringify(bookmarks))
+      },
+      getAccessibility: async () => parseAccessibilitySettings(await appConfig.get('accessibility')),
+      setAccessibility: async (settings) => {
+        await appConfig.set('accessibility', JSON.stringify(normalizeAccessibilitySettings(settings)))
       },
     },
     sounds: {

--- a/src/config/accessibility-settings.spec.ts
+++ b/src/config/accessibility-settings.spec.ts
@@ -1,0 +1,39 @@
+import {
+  DEFAULT_ACCESSIBILITY_SETTINGS,
+  normalizeAccessibilitySettings,
+  parseAccessibilitySettings,
+} from './accessibility-settings'
+
+describe('accessibility settings', () => {
+  it('defaults to pulses on and reduce-motion following the OS', () => {
+    expect(DEFAULT_ACCESSIBILITY_SETTINGS).toEqual({ luminancePulses: true, reduceMotion: null })
+  })
+
+  it('parses missing or malformed stored values as defaults', () => {
+    expect(parseAccessibilitySettings(null)).toEqual(DEFAULT_ACCESSIBILITY_SETTINGS)
+    expect(parseAccessibilitySettings('')).toEqual(DEFAULT_ACCESSIBILITY_SETTINGS)
+    expect(parseAccessibilitySettings('not json')).toEqual(DEFAULT_ACCESSIBILITY_SETTINGS)
+    expect(parseAccessibilitySettings('"a string"')).toEqual(DEFAULT_ACCESSIBILITY_SETTINGS)
+  })
+
+  it('parses a stored JSON payload', () => {
+    expect(parseAccessibilitySettings('{"luminancePulses":false,"reduceMotion":true}'))
+      .toEqual({ luminancePulses: false, reduceMotion: true })
+  })
+
+  it('falls back per field when a stored field has the wrong type', () => {
+    expect(parseAccessibilitySettings('{"luminancePulses":"nope","reduceMotion":"yes"}'))
+      .toEqual(DEFAULT_ACCESSIBILITY_SETTINGS)
+    expect(parseAccessibilitySettings('{"reduceMotion":false}'))
+      .toEqual({ luminancePulses: true, reduceMotion: false })
+  })
+
+  it('normalizes arbitrary input into a well-typed settings object', () => {
+    expect(normalizeAccessibilitySettings({ luminancePulses: false, reduceMotion: null }))
+      .toEqual({ luminancePulses: false, reduceMotion: null })
+    expect(normalizeAccessibilitySettings({ luminancePulses: 1, reduceMotion: 'x' } as never))
+      .toEqual(DEFAULT_ACCESSIBILITY_SETTINGS)
+    expect(normalizeAccessibilitySettings(undefined as never))
+      .toEqual(DEFAULT_ACCESSIBILITY_SETTINGS)
+  })
+})

--- a/src/config/accessibility-settings.ts
+++ b/src/config/accessibility-settings.ts
@@ -1,0 +1,33 @@
+export interface AccessibilitySettings {
+  luminancePulses: boolean
+  /** `null` follows the OS `prefers-reduced-motion` setting. */
+  reduceMotion: boolean | null
+}
+
+export const DEFAULT_ACCESSIBILITY_SETTINGS: AccessibilitySettings = {
+  luminancePulses: true,
+  reduceMotion: null,
+}
+
+export function normalizeAccessibilitySettings(input: Partial<AccessibilitySettings> | null | undefined): AccessibilitySettings {
+  const source = typeof input === 'object' && input !== null ? input : {}
+  return {
+    luminancePulses: typeof source.luminancePulses === 'boolean'
+      ? source.luminancePulses
+      : DEFAULT_ACCESSIBILITY_SETTINGS.luminancePulses,
+    reduceMotion: typeof source.reduceMotion === 'boolean'
+      ? source.reduceMotion
+      : DEFAULT_ACCESSIBILITY_SETTINGS.reduceMotion,
+  }
+}
+
+export function parseAccessibilitySettings(raw: string | null): AccessibilitySettings {
+  if (!raw)
+    return { ...DEFAULT_ACCESSIBILITY_SETTINGS }
+  try {
+    return normalizeAccessibilitySettings(JSON.parse(raw))
+  }
+  catch {
+    return { ...DEFAULT_ACCESSIBILITY_SETTINGS }
+  }
+}


### PR DESCRIPTION
Closes #318

## Summary

Status indicators now glow in rhythm so that **pulse rate and sharpness carry meaning alongside color** — a second, non-hue channel that's easier to catch from the corner of your eye mid-session and more accessible for colorblind / low-vision GMs.

### Shared pulse layer — `frontend/src/assets/pulse.css`
One `.pulse` base + five semantic variants (tint via `--pulse-color`; new states are just a class, no copied keyframes):

| class | meaning | rhythm |
|---|---|---|
| `pulse-steady` | idle / connected | static soft glow |
| `pulse-breathe` | ambience looping | 4s slow breathing |
| `pulse-busy` | connecting / joining | 1.4s even |
| `pulse-alert` | error / disconnected | 0.9s sharp attack |
| `pulse-flash` | one-shot effect fired / scene started | single 0.5s bright burst |

### Wired into
- Sidebar bot-status pill: steady / busy (reconnecting) / alert (disconnected)
- Channel dots: steady when connected, busy while joining
- Ambience cards: breathe while looping (new `playingAmbienceIds` set in SceneView)
- Effect cards: flash on fire; scene playback bar: flash on scene start (`useFlashSet` composable)

### Settings → Accessibility
- **Status pulses** toggle — off reverts indicators to plain color-only appearance
- **Reduce motion** toggle — follows OS `prefers-reduced-motion` by default, overridable in either direction, with a "Use system setting" reset
- New Pinia `accessibility` store mirrors effective state onto root classes (`pulses-off` / `reduce-motion` / `allow-motion`)
- Persisted in `app-config.json` under `accessibility` via the existing `config` domain (`getAccessibility` / `setAccessibility` in `bootstrap-embedded.ts`) — **no new IPC channels**, uses the generic `api` handler

Existing indicators (heartbeat dot, LIVE badges, browser-tab pulse) are untouched; with both toggles at default and OS reduced-motion off, everything looks as before plus the new pulses.

Also: `CLAUDE.md` updated to drop stale `app/` directory references (repo is a flat root package now), and the engineering-skills agent config from the earlier commit on this branch.

## Decisions worth a look
1. **Small backend addition** — the brief said "frontend-only" *and* "persist through the same config path as token/storage". Those conflict; I went with two accessor methods in the backend `config` domain (no IPC surface change). Easy to swap for `localStorage` if you'd rather stay strictly renderer-side.
2. **Explicit reduce-motion opt-out wins over the OS** — the global `prefers-reduced-motion` reset stays as the baseline but is scoped to `:root:not(.allow-motion)`, otherwise "overridable in either direction" would be a lie when the OS says reduce.

## Out of scope (per the brief)
Haptic/gamepad vibration, audio cues, OS notifications. Music-playback and missing-sound error states don't pulse (not in the acceptance criteria).

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` — 43 Jest + 181 Vitest pass (new specs: backend settings parser, config API wrappers, accessibility store, `useFlashSet`, App sidebar pulses, SceneView pulses, Settings toggles)
- [x] `pnpm build:frontend` OK
- [ ] Manual: launch app, watch sidebar pill go alert → busy → steady across Reconnect; play a scene with ambience and fire an effect; flip both Settings toggles and confirm indicators go color-only / motionless