### PR TITLE
feat(vision): Vision to Vibe — match tagged sounds to an image's mood

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,9 @@
 # Discord bot token (required — or set it in Settings inside the app)
 DISCORD_TOKEN=
 
+# Anthropic API key for Vision to Vibe (optional — or set it in Settings inside the app)
+# HIBIKI_VISION_API_KEY=
+
 # Storage paths (defaults below; relative to repo root or absolute)
 # HIBIKI_STORAGE_PATH=storage
 # HIBIKI_MUSIC_DIR=storage/music

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,7 @@ pnpm test:coverage:frontend               # Frontend only
 │   ├── sound/         # Sound library (list, upload, delete files)
 │   ├── scenes/        # Scene store + import/export (soundboards)
 │   ├── audio/         # Audio mixing (guild-specific managers)
+│   ├── vision/        # Vision to Vibe (Claude image analysis + Sound Tag matching)
 │   ├── config/        # Configuration (env + validation)
 │   └── persistence.ts # JSON key-value store (app-config.json)
 ├── frontend/          # Vue 3 renderer (Electron renderer process)
@@ -95,7 +96,7 @@ pnpm test:coverage:frontend               # Frontend only
 
 - **Frontend → Backend:** All communication uses Electron IPC via the `preload.js` bridge.
 - **IPC API:** Defined in `bootstrap-embedded.ts` as the `EmbeddedApi` interface.
-- **Domains:** `player`, `config`, `sounds`, `scenes` (matching the service structure).
+- **Domains:** `player`, `config`, `sounds`, `scenes`, `registry`, `vision` (matching the service structure).
 - Frontend wrappers in `frontend/src/api/` provide typed functions (e.g., `joinChannel()`, `listScenes()`).
 - Audio streaming (Browser feature) uses chunked IPC: `audio:startStream`, `audio:chunk`, `audio:stopStream`.
 
@@ -121,11 +122,12 @@ Stored in `scenes.json`. Import/export bundles scenes with their sound files as 
 ### Storage
 
 Data lives in platform user data directory (e.g., `~/Library/Application Support/hibiki` on macOS):
-- `app-config.json` — Discord token (when set in UI), bookmarks, storage path override
+- `app-config.json` — Discord token (when set in UI), bookmarks, storage path override, Vision to Vibe key + toggle
 - `scenes.json` — Scene definitions
+- `sound-tags.json` — Sound Tags keyed by `<category>/<soundId>` (see `CONTEXT.md` glossary)
 - `music/`, `effects/`, `ambience/` — Sound files (copied on upload, keyed by UUID)
 
-Override paths with env vars: `HIBIKI_STORAGE_PATH`, `HIBIKI_MUSIC_DIR`, `HIBIKI_EFFECTS_DIR`, `HIBIKI_DATA_PATH` (see `.env.example`).
+Override paths with env vars: `HIBIKI_STORAGE_PATH`, `HIBIKI_MUSIC_DIR`, `HIBIKI_EFFECTS_DIR`, `HIBIKI_DATA_PATH` (see `.env.example`). The Vision to Vibe API key can also come from `HIBIKI_VISION_API_KEY` (env wins over the stored key, like `DISCORD_TOKEN`).
 
 ## Key Development Patterns
 
@@ -153,6 +155,14 @@ The Browser tab captures audio from a `WebContentsView` (Electron-managed browse
 - **Backend:** `player.startStream(guildId, stream, metadata)` accepts a Node.js `ReadableStream`.
 - **Frontend → Main:** `audio:startStream`, chunked `audio:chunk`, `audio:stopStream`.
 - **Main process:** Creates `PassThrough` streams, writes chunks, pipes to backend.
+
+### Vision to Vibe
+
+Opt-in feature (off by default) that sends an image to Anthropic's Claude API and matches the returned Vibe Tags against the GM's own Sound Tags. See `agent-docs/adr/0001-vision-to-vibe-matching.md`.
+- Backend: `src/vision/vision.service.ts` (provider-agnostic `VisionProvider`, Claude is the only implementation) and `src/vision/vibe-matching.ts` (pure ranking, Music + Ambience only, top 5 per category).
+- Sound Tags live in `sound-tags.json` via `src/sound/sound-tags.store.ts`, merged into `SoundFile.tags` by the sound library.
+- Gating: the scene editor's "Vision to Vibe" button only renders when both the key is configured and the Settings toggle is on (`config.getVision`).
+- Never retain the analyzed image; it is read from disk, sent once, and dropped.
 
 ### Scene Playback
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - **Scenes** — Build soundboards with music tracks, ambience loops (with random interval repeats), and one-shot effects. Play an entire scene or individual tracks. Share scenes with the community or install from a [public registry](docs/scene-sharing.md).
 - **Browser** — Open any URL (YouTube, Spotify web, etc.) in a built-in browser tab and stream its audio to Discord. Bookmark your favourite sites.
 - **Media library** — Upload and manage your own sound files (music, effects, ambience). Import/export scenes as portable bundles.
+- **Vision to Vibe** *(opt-in)* — Drop a battle map or mood-board image into a scene and get Music and Ambience suggestions from your own tagged library. Uses your Anthropic API key (set in Settings or via `HIBIKI_VISION_API_KEY`); images are sent to Claude for analysis and never stored.
 - **App-only control** — The bot has no slash or prefix commands; everything is driven from the desktop UI.
 
 ## Stack
@@ -139,7 +140,8 @@ hibiki/
 
 Hibiki stores data as JSON files:
 
-- **`app-config.json`** — Discord token (when set in Settings), bookmarks, custom storage path.
+- **`app-config.json`** — Discord token (when set in Settings), bookmarks, custom storage path, Vision to Vibe API key and toggle.
+- **`sound-tags.json`** — Free-form tags you add to your Music/Ambience files (used by Vision to Vibe matching).
 - **`scenes.json`** — Scene definitions (soundboards with music, ambience, effects).
 - **Sound files** — stored on disk under `music/`, `effects/`, `ambience/` directories.
 

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -1,4 +1,4 @@
-const { contextBridge, ipcRenderer } = require('electron')
+const { contextBridge, ipcRenderer, webUtils } = require('electron')
 
 contextBridge.exposeInMainWorld('hibiki', {
   platform: process.platform,
@@ -9,4 +9,5 @@ contextBridge.exposeInMainWorld('hibiki', {
     ipcRenderer.on(channel, listener)
     return () => ipcRenderer.removeListener(channel, listener)
   },
+  getPathForFile: file => webUtils.getPathForFile(file),
 })

--- a/frontend/src/api/config.test.ts
+++ b/frontend/src/api/config.test.ts
@@ -3,6 +3,7 @@ import {
   fetchAccessibilitySettings,
   fetchDiscordConfig,
   fetchStoragePath,
+  fetchVisionConfig,
   listBookmarks,
   openFileDialog,
   saveBookmarks,
@@ -12,6 +13,8 @@ import {
   updateAccessibilitySettings,
   updateDiscordToken,
   updateStoragePath,
+  updateVisionApiKey,
+  updateVisionEnabled,
 } from './config'
 
 describe('config API', () => {
@@ -157,6 +160,37 @@ describe('config API', () => {
       domain: 'config',
       method: 'setAccessibility',
       args: [settings],
+    })
+  })
+
+  it('fetchVisionConfig uses apiCall', async () => {
+    mockInvoke.mockResolvedValue({ apiKeyConfigured: true, enabled: false })
+    const result = await fetchVisionConfig()
+    expect(mockInvoke).toHaveBeenCalledWith('api', {
+      domain: 'config',
+      method: 'getVision',
+      args: [],
+    })
+    expect(result).toEqual({ apiKeyConfigured: true, enabled: false })
+  })
+
+  it('updateVisionApiKey uses apiCall', async () => {
+    mockInvoke.mockResolvedValue({ apiKeyConfigured: true, enabled: false })
+    await updateVisionApiKey('sk-ant-123')
+    expect(mockInvoke).toHaveBeenCalledWith('api', {
+      domain: 'config',
+      method: 'setVisionApiKey',
+      args: ['sk-ant-123'],
+    })
+  })
+
+  it('updateVisionEnabled uses apiCall', async () => {
+    mockInvoke.mockResolvedValue({ apiKeyConfigured: true, enabled: true })
+    await updateVisionEnabled(true)
+    expect(mockInvoke).toHaveBeenCalledWith('api', {
+      domain: 'config',
+      method: 'setVisionEnabled',
+      args: [true],
     })
   })
 

--- a/frontend/src/api/config.ts
+++ b/frontend/src/api/config.ts
@@ -14,6 +14,11 @@ export interface AccessibilitySettings {
   reduceMotion: boolean | null
 }
 
+export interface VisionConfig {
+  apiKeyConfigured: boolean
+  enabled: boolean
+}
+
 function requireElectron(): void {
   if (!useElectronApi())
     throw new Error('Hibiki runs as an Electron app. Open it via pnpm run electron.')
@@ -94,4 +99,19 @@ export function listBookmarks(): Promise<Bookmark[]> {
 export function saveBookmarks(bookmarks: Bookmark[]): Promise<void> {
   requireElectron()
   return apiCall<void>('config', 'setBookmarks', [bookmarks])
+}
+
+export function fetchVisionConfig(): Promise<VisionConfig> {
+  requireElectron()
+  return apiCall<VisionConfig>('config', 'getVision', [])
+}
+
+export function updateVisionApiKey(apiKey: string): Promise<VisionConfig> {
+  requireElectron()
+  return apiCall<VisionConfig>('config', 'setVisionApiKey', [apiKey])
+}
+
+export function updateVisionEnabled(enabled: boolean): Promise<VisionConfig> {
+  requireElectron()
+  return apiCall<VisionConfig>('config', 'setVisionEnabled', [enabled])
 }

--- a/frontend/src/api/electron.test.ts
+++ b/frontend/src/api/electron.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest'
-import { apiCall, useElectronApi } from './electron'
+import { apiCall, getPathForFile, useElectronApi } from './electron'
 
 describe('electron API', () => {
   afterEach(() => {
@@ -12,5 +12,15 @@ describe('electron API', () => {
 
   it('apiCall throws when hibiki not available', () => {
     expect(() => apiCall('x', 'y', [])).toThrow('Electron API not available')
+  })
+
+  it('getPathForFile returns null when the bridge is missing', () => {
+    expect(getPathForFile(new File(['x'], 'map.png'))).toBeNull()
+  })
+
+  it('getPathForFile delegates to the bridge', () => {
+    const file = new File(['x'], 'map.png')
+    ;(window as any).hibiki = { getPathForFile: (f: File) => `/abs/${f.name}` }
+    expect(getPathForFile(file)).toBe('/abs/map.png')
   })
 })

--- a/frontend/src/api/electron.ts
+++ b/frontend/src/api/electron.ts
@@ -25,7 +25,6 @@ export function openExternal(url: string): void {
     window.hibiki.invoke('shell:openExternal', url)
 }
 
-/** Absolute filesystem path of a dropped/selected File, or null when the bridge can't resolve it. */
 export function getPathForFile(file: File): string | null {
   const resolved = window.hibiki?.getPathForFile?.(file)
   return typeof resolved === 'string' && resolved.length > 0 ? resolved : null

--- a/frontend/src/api/electron.ts
+++ b/frontend/src/api/electron.ts
@@ -5,6 +5,7 @@ declare global {
       invoke: (channel: string, ...args: unknown[]) => Promise<unknown>
       send: (channel: string, ...args: unknown[]) => void
       on: (channel: string, callback: (...args: unknown[]) => void) => () => void
+      getPathForFile?: (file: File) => string
     }
   }
 }
@@ -22,4 +23,10 @@ export function apiCall<T>(domain: string, method: string, args: unknown[]): Pro
 export function openExternal(url: string): void {
   if (window.hibiki?.invoke)
     window.hibiki.invoke('shell:openExternal', url)
+}
+
+/** Absolute filesystem path of a dropped/selected File, or null when the bridge can't resolve it. */
+export function getPathForFile(file: File): string | null {
+  const resolved = window.hibiki?.getPathForFile?.(file)
+  return typeof resolved === 'string' && resolved.length > 0 ? resolved : null
 }

--- a/frontend/src/api/sounds.test.ts
+++ b/frontend/src/api/sounds.test.ts
@@ -4,6 +4,7 @@ import {
   listEffects,
   listMusic,
   soundStreamUrl,
+  updateSoundTags,
   uploadSound,
   uploadSoundsBulk,
 } from './sounds'
@@ -62,6 +63,17 @@ describe('sounds API', () => {
       method: 'deleteSound',
       args: ['effects', 'id1'],
     })
+  })
+
+  it('updateSoundTags uses apiCall', async () => {
+    mockInvoke.mockResolvedValue(['tavern', 'warm'])
+    const result = await updateSoundTags('music', 'id1', ['tavern', 'warm'])
+    expect(mockInvoke).toHaveBeenCalledWith('api', {
+      domain: 'sounds',
+      method: 'setTags',
+      args: ['music', 'id1', ['tavern', 'warm']],
+    })
+    expect(result).toEqual(['tavern', 'warm'])
   })
 
   it('soundStreamUrl returns hibiki URL', () => {

--- a/frontend/src/api/sounds.ts
+++ b/frontend/src/api/sounds.ts
@@ -8,6 +8,7 @@ export interface SoundFile {
   size?: number
   path?: string
   createdAt?: string
+  tags?: string[]
 }
 
 function requireElectron(): void {
@@ -58,6 +59,11 @@ export async function uploadSoundsBulk(
 export function deleteSound(type: 'music' | 'effects' | 'ambience', id: string) {
   requireElectron()
   return apiCall<void>('sounds', 'deleteSound', [type, id])
+}
+
+export function updateSoundTags(type: 'music' | 'effects' | 'ambience', id: string, tags: string[]) {
+  requireElectron()
+  return apiCall<string[]>('sounds', 'setTags', [type, id, tags])
 }
 
 /** URL to stream a sound for playback (use in <audio src="...">) */

--- a/frontend/src/api/vision.test.ts
+++ b/frontend/src/api/vision.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { analyzeImageVibe, matchVibe } from './vision'
+
+describe('vision API', () => {
+  const mockInvoke = vi.fn()
+
+  beforeEach(() => {
+    ;(window as any).hibiki = { invoke: mockInvoke }
+  })
+  afterEach(() => {
+    delete (window as any).hibiki
+  })
+
+  it('analyzeImageVibe uses apiCall with the image path', async () => {
+    const analysis = { description: 'A stormy coast', tags: ['stormy', 'coast'] }
+    mockInvoke.mockResolvedValue(analysis)
+    const result = await analyzeImageVibe('/tmp/map.png')
+    expect(mockInvoke).toHaveBeenCalledWith('api', {
+      domain: 'vision',
+      method: 'analyzeImageVibe',
+      args: ['/tmp/map.png'],
+    })
+    expect(result).toEqual(analysis)
+  })
+
+  it('matchVibe uses apiCall with the vibe tags', async () => {
+    const matches = { music: [], ambience: [] }
+    mockInvoke.mockResolvedValue(matches)
+    const result = await matchVibe(['stormy'])
+    expect(mockInvoke).toHaveBeenCalledWith('api', {
+      domain: 'vision',
+      method: 'matchVibe',
+      args: [['stormy']],
+    })
+    expect(result).toEqual(matches)
+  })
+
+  it('throws when not in Electron', () => {
+    delete (window as any).hibiki
+    expect(() => analyzeImageVibe('/tmp/map.png')).toThrow('Electron app')
+  })
+})

--- a/frontend/src/api/vision.ts
+++ b/frontend/src/api/vision.ts
@@ -1,0 +1,32 @@
+import type { SoundFile } from './sounds'
+import { apiCall, useElectronApi } from './electron'
+
+export interface VibeAnalysis {
+  description: string
+  tags: string[]
+}
+
+export interface VibeMatch {
+  sound: SoundFile
+  score: number
+}
+
+export interface VibeMatches {
+  music: VibeMatch[]
+  ambience: VibeMatch[]
+}
+
+function requireElectron(): void {
+  if (!useElectronApi())
+    throw new Error('Hibiki runs as an Electron app. Open it via pnpm run electron.')
+}
+
+export function analyzeImageVibe(imagePath: string): Promise<VibeAnalysis> {
+  requireElectron()
+  return apiCall<VibeAnalysis>('vision', 'analyzeImageVibe', [imagePath])
+}
+
+export function matchVibe(vibeTags: string[]): Promise<VibeMatches> {
+  requireElectron()
+  return apiCall<VibeMatches>('vision', 'matchVibe', [vibeTags])
+}

--- a/frontend/src/components/SoundListManage.spec.ts
+++ b/frontend/src/components/SoundListManage.spec.ts
@@ -9,6 +9,7 @@ vi.mock('@/api/sounds', () => ({
   uploadSound: vi.fn().mockResolvedValue({}),
   uploadSoundsBulk: vi.fn().mockResolvedValue({ success: [], failed: [] }),
   deleteSound: vi.fn().mockResolvedValue(undefined),
+  updateSoundTags: vi.fn().mockImplementation(async (_type: string, _id: string, tags: string[]) => tags),
   soundStreamUrl: (type: string, id: string) => `hibiki://sound/${type}/${id}`,
 }))
 
@@ -325,5 +326,78 @@ describe('soundListManage', () => {
 
     expect(wrapper.find('.toast-success').exists()).toBe(false)
     vi.useRealTimers()
+  })
+
+  describe('sound tags', () => {
+    it('shows existing tags as chips for music', async () => {
+      const { listMusic } = await import('@/api/sounds')
+      vi.mocked(listMusic).mockResolvedValue([
+        { id: 's1', name: 'Tavern', filename: 't.mp3', category: 'music', createdAt: '2024-01-01T00:00:00Z', tags: ['warm', 'candlelit'] },
+      ])
+      const wrapper = mount(SoundListManage, { props: { type: 'music' } })
+      await flushPromises()
+      const chips = wrapper.findAll('.tag-chip')
+      expect(chips.map(c => c.text())).toEqual(['warm', 'candlelit'])
+    })
+
+    it('does not offer tag editing for effects', async () => {
+      const { listEffects } = await import('@/api/sounds')
+      vi.mocked(listEffects).mockResolvedValue([
+        { id: 'e1', name: 'Boom', filename: 'b.wav', category: 'effects', createdAt: '2024-01-01T00:00:00Z', tags: [] },
+      ])
+      const wrapper = mount(SoundListManage, { props: { type: 'effects' } })
+      await flushPromises()
+      expect(wrapper.find('.btn-edit-tags').exists()).toBe(false)
+    })
+
+    it('edits tags inline and saves them comma-separated', async () => {
+      const { listAmbience, updateSoundTags } = await import('@/api/sounds')
+      vi.mocked(listAmbience).mockResolvedValue([
+        { id: 'a1', name: 'Rain', filename: 'r.mp3', category: 'ambience', createdAt: '2024-01-01T00:00:00Z', tags: [] },
+      ])
+      const wrapper = mount(SoundListManage, { props: { type: 'ambience' } })
+      await flushPromises()
+      await wrapper.find('.btn-edit-tags').trigger('click')
+      const input = wrapper.find('input.tags-input')
+      expect(input.exists()).toBe(true)
+      await input.setValue('stormy, wet , night')
+      await input.trigger('keydown.enter')
+      await flushPromises()
+      expect(updateSoundTags).toHaveBeenCalledWith('ambience', 'a1', ['stormy', 'wet', 'night'])
+      expect(wrapper.findAll('.tag-chip').map(c => c.text())).toEqual(['stormy', 'wet', 'night'])
+      expect(wrapper.find('input.tags-input').exists()).toBe(false)
+    })
+
+    it('escape cancels tag editing without saving', async () => {
+      const { listAmbience, updateSoundTags } = await import('@/api/sounds')
+      vi.mocked(updateSoundTags).mockClear()
+      vi.mocked(listAmbience).mockResolvedValue([
+        { id: 'a1', name: 'Rain', filename: 'r.mp3', category: 'ambience', createdAt: '2024-01-01T00:00:00Z', tags: ['old'] },
+      ])
+      const wrapper = mount(SoundListManage, { props: { type: 'ambience' } })
+      await flushPromises()
+      await wrapper.find('.btn-edit-tags').trigger('click')
+      const input = wrapper.find('input.tags-input')
+      await input.setValue('new')
+      await input.trigger('keydown.escape')
+      await flushPromises()
+      expect(updateSoundTags).not.toHaveBeenCalled()
+      expect(wrapper.findAll('.tag-chip').map(c => c.text())).toEqual(['old'])
+    })
+
+    it('shows an error toast when saving tags fails', async () => {
+      const { listMusic, updateSoundTags } = await import('@/api/sounds')
+      vi.mocked(listMusic).mockResolvedValue([
+        { id: 's1', name: 'Tavern', filename: 't.mp3', category: 'music', createdAt: '2024-01-01T00:00:00Z', tags: [] },
+      ])
+      vi.mocked(updateSoundTags).mockRejectedValueOnce(new Error('disk full'))
+      const wrapper = mount(SoundListManage, { props: { type: 'music' } })
+      await flushPromises()
+      await wrapper.find('.btn-edit-tags').trigger('click')
+      await wrapper.find('input.tags-input').setValue('x')
+      await wrapper.find('input.tags-input').trigger('keydown.enter')
+      await flushPromises()
+      expect(wrapper.find('.toast-error').text()).toContain('disk full')
+    })
   })
 })

--- a/frontend/src/components/SoundListManage.vue
+++ b/frontend/src/components/SoundListManage.vue
@@ -7,6 +7,7 @@ import {
   listEffects,
   listMusic,
   soundStreamUrl,
+  updateSoundTags,
   uploadSound,
   uploadSoundsBulk,
 } from '@/api/sounds'
@@ -34,6 +35,12 @@ const audioEl = ref<HTMLAudioElement | null>(null)
 const fileInputRef = ref<HTMLInputElement | null>(null)
 const toast = ref<{ type: 'success' | 'error', text: string } | null>(null)
 let toastTimer: ReturnType<typeof setTimeout> | null = null
+const editingTagsId = ref<string | null>(null)
+const tagsDraft = ref('')
+const savingTags = ref(false)
+const tagsInputRef = ref<HTMLInputElement[]>([])
+
+const supportsTags = computed(() => props.type !== 'effects')
 
 function showToast(type: 'success' | 'error', text: string) {
   if (toastTimer)
@@ -226,6 +233,40 @@ async function confirmDelete(id: string) {
   }
 }
 
+function parseTags(raw: string): string[] {
+  return raw.split(',').map(t => t.trim()).filter(t => t.length > 0)
+}
+
+async function startEditTags(sound: SoundFile) {
+  editingTagsId.value = sound.id
+  tagsDraft.value = (sound.tags ?? []).join(', ')
+  await nextTick()
+  tagsInputRef.value[0]?.focus()
+}
+
+function cancelEditTags() {
+  editingTagsId.value = null
+  tagsDraft.value = ''
+}
+
+async function saveTags(sound: SoundFile) {
+  if (editingTagsId.value !== sound.id || savingTags.value)
+    return
+  savingTags.value = true
+  try {
+    const saved = await updateSoundTags(props.type, sound.id, parseTags(tagsDraft.value))
+    items.value = items.value.map(s => (s.id === sound.id ? { ...s, tags: saved } : s))
+    cancelEditTags()
+    emit('updated')
+  }
+  catch (err) {
+    showToast('error', err instanceof Error ? err.message : 'Couldn\'t save tags. Try again.')
+  }
+  finally {
+    savingTags.value = false
+  }
+}
+
 onMounted(() => {
   loadSounds()
 })
@@ -322,6 +363,36 @@ onActivated(() => {
         </button>
 
         <span class="sound-name" :title="sound.name">{{ sound.name }}</span>
+
+        <div v-if="supportsTags" class="sound-tags">
+          <template v-if="editingTagsId === sound.id">
+            <input
+              ref="tagsInputRef"
+              v-model="tagsDraft"
+              type="text"
+              class="input tags-input"
+              placeholder="tavern, warm, night"
+              :aria-label="`Tags for ${sound.name}`"
+              :disabled="savingTags"
+              @keydown.enter.prevent="saveTags(sound)"
+              @keydown.escape.prevent="cancelEditTags"
+              @blur="saveTags(sound)"
+            >
+          </template>
+          <template v-else>
+            <span v-for="tag in sound.tags ?? []" :key="tag" class="tag-chip">{{ tag }}</span>
+            <button
+              type="button"
+              class="btn-edit-tags"
+              :class="{ 'btn-edit-tags-empty': !(sound.tags?.length) }"
+              :title="sound.tags?.length ? 'Edit tags' : 'Add tags for Vision to Vibe matching'"
+              :aria-label="`Edit tags for ${sound.name}`"
+              @click="startEditTags(sound)"
+            >
+              {{ sound.tags?.length ? '✎' : '+ tags' }}
+            </button>
+          </template>
+        </div>
 
         <span class="sound-ext">{{ fileExt(sound.filename) }}</span>
         <span v-if="sound.size" class="sound-meta">{{ formatSize(sound.size) }}</span>
@@ -559,6 +630,64 @@ onActivated(() => {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* ── Sound tags ── */
+
+.sound-tags {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  flex-wrap: wrap;
+  flex-shrink: 1;
+  min-width: 0;
+  max-width: 45%;
+}
+
+.tag-chip {
+  font-size: 0.7rem;
+  padding: 0.1rem 0.45rem;
+  border-radius: 999px;
+  background: var(--color-accent-muted);
+  color: var(--color-accent-hover);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 10rem;
+}
+
+.btn-edit-tags {
+  border: none;
+  background: transparent;
+  color: var(--color-text-dim);
+  font-size: 0.7rem;
+  padding: 0.1rem 0.35rem;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity var(--transition), color var(--transition), background var(--transition);
+}
+
+.btn-edit-tags-empty {
+  border: 1px dashed var(--color-border);
+}
+
+.sound-item:hover .btn-edit-tags,
+.sound-item:focus-within .btn-edit-tags,
+.btn-edit-tags:focus-visible {
+  opacity: 1;
+}
+
+.btn-edit-tags:hover {
+  color: var(--color-text);
+  background: var(--color-bg-elevated);
+}
+
+.tags-input {
+  width: 16rem;
+  max-width: 100%;
+  padding: 0.2rem 0.5rem;
+  font-size: 0.75rem;
 }
 
 .sound-ext {

--- a/frontend/src/components/VisionToVibeDialog.spec.ts
+++ b/frontend/src/components/VisionToVibeDialog.spec.ts
@@ -1,0 +1,136 @@
+import type { SoundFile } from '@/api/sounds'
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { openFileDialog } from '@/api/config'
+import { analyzeImageVibe, matchVibe } from '@/api/vision'
+import VisionToVibeDialog from './VisionToVibeDialog.vue'
+
+vi.mock('@/api/config', () => ({
+  openFileDialog: vi.fn(),
+}))
+
+vi.mock('@/api/vision', () => ({
+  analyzeImageVibe: vi.fn(),
+  matchVibe: vi.fn(),
+}))
+
+const router = { push: vi.fn() }
+vi.mock('vue-router', () => ({
+  RouterLink: { template: '<a><slot /></a>' },
+  useRouter: () => router,
+}))
+
+function sound(id: string, category: 'music' | 'ambience', tags: string[] = []): SoundFile {
+  return { id, name: id.toUpperCase(), filename: `${id}.mp3`, category, createdAt: '2026-01-01T00:00:00Z', tags }
+}
+
+const tavern = sound('tavern', 'music', ['warm', 'tavern'])
+const rain = sound('rain', 'ambience', ['storm', 'wet'])
+
+function mountDialog(overrides: Partial<{ musicSounds: SoundFile[], ambienceSounds: SoundFile[], musicInScene: string[], ambienceInScene: string[] }> = {}) {
+  return mount(VisionToVibeDialog, {
+    props: {
+      musicSounds: [tavern],
+      ambienceSounds: [rain],
+      musicInScene: [],
+      ambienceInScene: [],
+      ...overrides,
+    },
+  })
+}
+
+describe('visionToVibeDialog', () => {
+  beforeEach(() => {
+    vi.mocked(openFileDialog).mockReset()
+    vi.mocked(analyzeImageVibe).mockReset()
+    vi.mocked(matchVibe).mockReset()
+  })
+
+  it('starts on the image picker with a third-party disclosure', () => {
+    const wrapper = mountDialog()
+    expect(wrapper.find('[data-testid="vibe-pick-image"]').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Anthropic')
+  })
+
+  it('analyzes the chosen image and shows description, tags, and matches', async () => {
+    vi.mocked(openFileDialog).mockResolvedValue('/tmp/map.png')
+    vi.mocked(analyzeImageVibe).mockResolvedValue({ description: 'A cozy tavern.', tags: ['warm', 'tavern'] })
+    vi.mocked(matchVibe).mockResolvedValue({ music: [{ sound: tavern, score: 2 }], ambience: [] })
+    const wrapper = mountDialog()
+    await wrapper.find('[data-testid="vibe-pick-image"]').trigger('click')
+    await flushPromises()
+    expect(analyzeImageVibe).toHaveBeenCalledWith('/tmp/map.png')
+    expect(matchVibe).toHaveBeenCalledWith(['warm', 'tavern'])
+    expect(wrapper.text()).toContain('A cozy tavern.')
+    expect(wrapper.findAll('.vibe-tag').map(t => t.text())).toEqual(['warm', 'tavern'])
+    expect(wrapper.find('[data-testid="vibe-music-matches"]').text()).toContain('TAVERN')
+  })
+
+  it('emits add for a single match without touching the others', async () => {
+    vi.mocked(openFileDialog).mockResolvedValue('/tmp/map.png')
+    vi.mocked(analyzeImageVibe).mockResolvedValue({ description: 'Storm.', tags: ['storm'] })
+    vi.mocked(matchVibe).mockResolvedValue({ music: [], ambience: [{ sound: rain, score: 1 }] })
+    const wrapper = mountDialog()
+    await wrapper.find('[data-testid="vibe-pick-image"]').trigger('click')
+    await flushPromises()
+    await wrapper.find('[data-testid="vibe-ambience-matches"] .btn-add-match').trigger('click')
+    expect(wrapper.emitted('add')).toEqual([['ambience', rain]])
+  })
+
+  it('marks matches that are already in the scene', async () => {
+    vi.mocked(openFileDialog).mockResolvedValue('/tmp/map.png')
+    vi.mocked(analyzeImageVibe).mockResolvedValue({ description: 'Storm.', tags: ['storm'] })
+    vi.mocked(matchVibe).mockResolvedValue({ music: [], ambience: [{ sound: rain, score: 1 }] })
+    const wrapper = mountDialog({ ambienceInScene: ['rain'] })
+    await wrapper.find('[data-testid="vibe-pick-image"]').trigger('click')
+    await flushPromises()
+    const btn = wrapper.find<HTMLButtonElement>('[data-testid="vibe-ambience-matches"] .btn-add-match')
+    expect(btn.element.disabled).toBe(true)
+    expect(btn.text()).toContain('Added')
+  })
+
+  it('explains the tagging gap when a category has no tagged sounds', async () => {
+    vi.mocked(openFileDialog).mockResolvedValue('/tmp/map.png')
+    vi.mocked(analyzeImageVibe).mockResolvedValue({ description: 'Storm.', tags: ['storm'] })
+    vi.mocked(matchVibe).mockResolvedValue({ music: [], ambience: [] })
+    const wrapper = mountDialog({ musicSounds: [sound('untagged', 'music')], ambienceSounds: [] })
+    await wrapper.find('[data-testid="vibe-pick-image"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.find('[data-testid="vibe-music-empty"]').text()).toMatch(/tag your/i)
+    expect(wrapper.find('[data-testid="vibe-ambience-empty"]').text()).toMatch(/tag your/i)
+  })
+
+  it('says when tagged sounds simply did not match', async () => {
+    vi.mocked(openFileDialog).mockResolvedValue('/tmp/map.png')
+    vi.mocked(analyzeImageVibe).mockResolvedValue({ description: 'Storm.', tags: ['storm'] })
+    vi.mocked(matchVibe).mockResolvedValue({ music: [], ambience: [] })
+    const wrapper = mountDialog()
+    await wrapper.find('[data-testid="vibe-pick-image"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.find('[data-testid="vibe-music-empty"]').text()).toMatch(/no music matched/i)
+  })
+
+  it('shows the error and returns to the picker when analysis fails', async () => {
+    vi.mocked(openFileDialog).mockResolvedValue('/tmp/map.png')
+    vi.mocked(analyzeImageVibe).mockRejectedValue(new Error('rate limited'))
+    const wrapper = mountDialog()
+    await wrapper.find('[data-testid="vibe-pick-image"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.find('.vibe-error').text()).toContain('rate limited')
+    expect(wrapper.find('[data-testid="vibe-pick-image"]').exists()).toBe(true)
+  })
+
+  it('does nothing when the file dialog is cancelled', async () => {
+    vi.mocked(openFileDialog).mockResolvedValue(null)
+    const wrapper = mountDialog()
+    await wrapper.find('[data-testid="vibe-pick-image"]').trigger('click')
+    await flushPromises()
+    expect(analyzeImageVibe).not.toHaveBeenCalled()
+  })
+
+  it('emits close from the close button', async () => {
+    const wrapper = mountDialog()
+    await wrapper.find('.btn-close').trigger('click')
+    expect(wrapper.emitted('close')).toHaveLength(1)
+  })
+})

--- a/frontend/src/components/VisionToVibeDialog.spec.ts
+++ b/frontend/src/components/VisionToVibeDialog.spec.ts
@@ -128,6 +128,14 @@ describe('visionToVibeDialog', () => {
     expect(analyzeImageVibe).not.toHaveBeenCalled()
   })
 
+  it('emits close on Escape', async () => {
+    const wrapper = mountDialog()
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    await flushPromises()
+    expect(wrapper.emitted('close')).toHaveLength(1)
+    wrapper.unmount()
+  })
+
   it('emits close from the close button', async () => {
     const wrapper = mountDialog()
     await wrapper.find('.btn-close').trigger('click')

--- a/frontend/src/components/VisionToVibeDialog.vue
+++ b/frontend/src/components/VisionToVibeDialog.vue
@@ -1,0 +1,571 @@
+<script setup lang="ts">
+import type { SoundFile } from '@/api/sounds'
+import type { VibeAnalysis, VibeMatch, VibeMatches } from '@/api/vision'
+import { computed, ref } from 'vue'
+import { RouterLink } from 'vue-router'
+import { openFileDialog } from '@/api/config'
+import { getPathForFile } from '@/api/electron'
+import { analyzeImageVibe, matchVibe } from '@/api/vision'
+
+type MatchCategory = 'music' | 'ambience'
+
+const props = defineProps<{
+  musicSounds: SoundFile[]
+  ambienceSounds: SoundFile[]
+  musicInScene: string[]
+  ambienceInScene: string[]
+}>()
+
+const emit = defineEmits<{
+  add: [category: MatchCategory, sound: SoundFile]
+  close: []
+}>()
+
+const IMAGE_EXTENSIONS = ['png', 'jpg', 'jpeg', 'gif', 'webp']
+
+const stage = ref<'pick' | 'analyzing' | 'results'>('pick')
+const analysis = ref<VibeAnalysis | null>(null)
+const matches = ref<VibeMatches | null>(null)
+const error = ref<string | null>(null)
+const imageName = ref<string | null>(null)
+const dragOver = ref(false)
+
+const hasTaggedMusic = computed(() => props.musicSounds.some(s => (s.tags?.length ?? 0) > 0))
+const hasTaggedAmbience = computed(() => props.ambienceSounds.some(s => (s.tags?.length ?? 0) > 0))
+
+function isInScene(category: MatchCategory, soundId: string): boolean {
+  const ids = category === 'music' ? props.musicInScene : props.ambienceInScene
+  return ids.includes(soundId)
+}
+
+function fileNameOf(path: string): string {
+  return path.split(/[\\/]/).pop() ?? path
+}
+
+function hasImageExtension(name: string): boolean {
+  const ext = name.split('.').pop()?.toLowerCase() ?? ''
+  return IMAGE_EXTENSIONS.includes(ext)
+}
+
+async function analyze(imagePath: string) {
+  stage.value = 'analyzing'
+  error.value = null
+  imageName.value = fileNameOf(imagePath)
+  try {
+    const result = await analyzeImageVibe(imagePath)
+    analysis.value = result
+    matches.value = await matchVibe(result.tags)
+    stage.value = 'results'
+  }
+  catch (err) {
+    error.value = err instanceof Error ? err.message : 'Couldn\'t analyze this image. Try another one.'
+    stage.value = 'pick'
+  }
+}
+
+async function pickImage() {
+  const path = await openFileDialog({
+    title: 'Choose an image for Vision to Vibe',
+    filters: [{ name: 'Images', extensions: IMAGE_EXTENSIONS }],
+  })
+  if (path)
+    await analyze(path)
+}
+
+function onDrop(e: DragEvent) {
+  e.preventDefault()
+  dragOver.value = false
+  if (stage.value === 'analyzing')
+    return
+  const file = e.dataTransfer?.files?.[0]
+  if (!file)
+    return
+  if (!hasImageExtension(file.name)) {
+    error.value = 'That doesn\'t look like an image. Drop a PNG, JPEG, GIF, or WebP file.'
+    return
+  }
+  const path = getPathForFile(file)
+  if (!path) {
+    error.value = 'Couldn\'t read that file\'s location. Use "Choose image" instead.'
+    return
+  }
+  analyze(path)
+}
+
+function onDragOver(e: DragEvent) {
+  e.preventDefault()
+  if (e.dataTransfer)
+    e.dataTransfer.dropEffect = 'copy'
+  dragOver.value = true
+}
+
+function reset() {
+  stage.value = 'pick'
+  analysis.value = null
+  matches.value = null
+  error.value = null
+  imageName.value = null
+}
+
+function scoreLabel(match: VibeMatch): string {
+  return `${match.score} ${match.score === 1 ? 'tag' : 'tags'} in common`
+}
+</script>
+
+<template>
+  <div class="vibe-overlay" @click.self="emit('close')">
+    <div class="vibe-modal" role="dialog" aria-label="Vision to Vibe">
+      <header class="vibe-header">
+        <div>
+          <h2 class="vibe-title">
+            Vision to Vibe
+          </h2>
+          <p class="vibe-subtitle">
+            Drop in a battle map or mood board — get matching sounds from your tagged library.
+          </p>
+        </div>
+        <button type="button" class="btn-close" aria-label="Close" @click="emit('close')">
+          ×
+        </button>
+      </header>
+
+      <div class="vibe-body">
+        <p v-if="error" class="vibe-error" role="alert">
+          {{ error }}
+        </p>
+
+        <div
+          v-if="stage !== 'results'"
+          class="drop-zone"
+          :class="{ 'drop-zone-active': dragOver, 'drop-zone-busy': stage === 'analyzing' }"
+          @drop="onDrop"
+          @dragover="onDragOver"
+          @dragleave="dragOver = false"
+        >
+          <template v-if="stage === 'analyzing'">
+            <span class="drop-spinner" aria-hidden="true" />
+            <p class="drop-title">
+              Reading the vibe of <strong>{{ imageName }}</strong>…
+            </p>
+            <p class="drop-hint">
+              This usually takes a few seconds.
+            </p>
+          </template>
+          <template v-else>
+            <p class="drop-title">
+              Drag an image here
+            </p>
+            <p class="drop-hint">
+              or
+            </p>
+            <button type="button" class="btn btn-primary" data-testid="vibe-pick-image" @click="pickImage">
+              Choose image…
+            </button>
+            <p class="drop-privacy">
+              The image is sent to Anthropic's Claude API for analysis and isn't kept afterwards.
+            </p>
+          </template>
+        </div>
+
+        <template v-else-if="analysis && matches">
+          <section class="vibe-analysis">
+            <p class="vibe-image-name">
+              {{ imageName }}
+            </p>
+            <p class="vibe-description">
+              {{ analysis.description }}
+            </p>
+            <ul class="vibe-tags" aria-label="Vibe tags">
+              <li v-for="tag in analysis.tags" :key="tag" class="vibe-tag">
+                {{ tag }}
+              </li>
+            </ul>
+          </section>
+
+          <div class="match-columns">
+            <section class="match-column match-column-music" data-testid="vibe-music-matches">
+              <h3 class="match-title">
+                Music
+              </h3>
+              <ul v-if="matches.music.length" class="match-list">
+                <li v-for="match in matches.music" :key="match.sound.id" class="match-item">
+                  <div class="match-info">
+                    <span class="match-name" :title="match.sound.name">{{ match.sound.name }}</span>
+                    <span class="match-score">{{ scoreLabel(match) }}</span>
+                  </div>
+                  <button
+                    type="button"
+                    class="btn-add-match"
+                    :disabled="isInScene('music', match.sound.id)"
+                    @click="emit('add', 'music', match.sound)"
+                  >
+                    {{ isInScene('music', match.sound.id) ? '✓ Added' : '+ Add' }}
+                  </button>
+                </li>
+              </ul>
+              <p v-else-if="!hasTaggedMusic" class="match-empty" data-testid="vibe-music-empty">
+                Tag your Music sounds to enable Vision-to-Vibe matching.
+                <RouterLink to="/media" class="match-link">
+                  Open the sound library
+                </RouterLink>
+              </p>
+              <p v-else class="match-empty" data-testid="vibe-music-empty">
+                No Music matched these tags. Try tagging more tracks with moods and settings.
+              </p>
+            </section>
+
+            <section class="match-column match-column-ambience" data-testid="vibe-ambience-matches">
+              <h3 class="match-title">
+                Ambience
+              </h3>
+              <ul v-if="matches.ambience.length" class="match-list">
+                <li v-for="match in matches.ambience" :key="match.sound.id" class="match-item">
+                  <div class="match-info">
+                    <span class="match-name" :title="match.sound.name">{{ match.sound.name }}</span>
+                    <span class="match-score">{{ scoreLabel(match) }}</span>
+                  </div>
+                  <button
+                    type="button"
+                    class="btn-add-match"
+                    :disabled="isInScene('ambience', match.sound.id)"
+                    @click="emit('add', 'ambience', match.sound)"
+                  >
+                    {{ isInScene('ambience', match.sound.id) ? '✓ Added' : '+ Add' }}
+                  </button>
+                </li>
+              </ul>
+              <p v-else-if="!hasTaggedAmbience" class="match-empty" data-testid="vibe-ambience-empty">
+                Tag your Ambience sounds to enable Vision-to-Vibe matching.
+                <RouterLink to="/media" class="match-link">
+                  Open the sound library
+                </RouterLink>
+              </p>
+              <p v-else class="match-empty" data-testid="vibe-ambience-empty">
+                No Ambience matched these tags. Try tagging more loops with moods and settings.
+              </p>
+            </section>
+          </div>
+
+          <footer class="vibe-footer">
+            <button type="button" class="btn btn-ghost" @click="reset">
+              Analyze another image
+            </button>
+            <button type="button" class="btn btn-primary" @click="emit('close')">
+              Done
+            </button>
+          </footer>
+        </template>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.vibe-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-backdrop);
+  backdrop-filter: blur(4px);
+}
+
+.vibe-modal {
+  display: flex;
+  flex-direction: column;
+  width: min(640px, 92vw);
+  max-height: 88vh;
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.vibe-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.vibe-title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.vibe-subtitle {
+  margin: 0.2rem 0 0;
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+}
+
+.btn-close {
+  background: none;
+  border: none;
+  color: var(--color-text-muted);
+  font-size: 1.5rem;
+  cursor: pointer;
+  padding: 0 0.25rem;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.btn-close:hover {
+  color: var(--color-text);
+}
+
+.vibe-body {
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  overflow-y: auto;
+  min-height: 0;
+}
+
+.vibe-error {
+  margin: 0;
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--radius-sm);
+  background: var(--color-error-muted);
+  color: var(--color-error);
+  font-size: 0.85rem;
+}
+
+/* ── Drop zone ── */
+
+.drop-zone {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 2.5rem 1.5rem;
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius-md);
+  text-align: center;
+  transition: background var(--transition), border-color var(--transition);
+}
+
+.drop-zone-active {
+  background: var(--color-accent-muted);
+  border-color: var(--color-accent);
+}
+
+.drop-zone-busy {
+  border-style: solid;
+}
+
+.drop-title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: var(--color-text);
+}
+
+.drop-hint {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--color-text-dim);
+}
+
+.drop-privacy {
+  margin: 0.75rem 0 0;
+  max-width: 28rem;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  color: var(--color-text-muted);
+}
+
+.drop-spinner {
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 50%;
+  border: 2px solid var(--color-border);
+  border-top-color: var(--color-accent);
+  animation: vibe-spin 0.8s linear infinite;
+}
+
+@keyframes vibe-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .drop-spinner {
+    animation: none;
+  }
+}
+
+/* ── Analysis ── */
+
+.vibe-analysis {
+  padding: 0.85rem 1rem;
+  background: var(--color-bg);
+  border-radius: var(--radius-md);
+}
+
+.vibe-image-name {
+  margin: 0 0 0.25rem;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-text-dim);
+}
+
+.vibe-description {
+  margin: 0 0 0.6rem;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: var(--color-text);
+}
+
+.vibe-tags {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.vibe-tag {
+  font-size: 0.75rem;
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  background: var(--color-accent-muted);
+  color: var(--color-accent-hover);
+}
+
+/* ── Matches ── */
+
+.match-columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+.match-column {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.match-title {
+  margin: 0;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding-left: 0.5rem;
+  border-left: 3px solid var(--color-music);
+  color: var(--color-text-muted);
+}
+
+.match-column-ambience .match-title {
+  border-left-color: var(--color-ambience);
+}
+
+.match-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.match-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.45rem 0.6rem;
+  border-radius: var(--radius-sm);
+  background: var(--color-bg);
+}
+
+.match-info {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.match-name {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--color-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.match-score {
+  font-size: 0.7rem;
+  color: var(--color-text-dim);
+}
+
+.btn-add-match {
+  flex-shrink: 0;
+  padding: 0.25rem 0.55rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: var(--color-accent);
+  color: var(--color-accent-text);
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background var(--transition);
+}
+
+.btn-add-match:hover:not(:disabled) {
+  background: var(--color-accent-hover);
+}
+
+.btn-add-match:disabled {
+  background: transparent;
+  color: var(--color-success);
+  cursor: default;
+}
+
+.match-empty {
+  margin: 0;
+  padding: 0.75rem;
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius-sm);
+  font-size: 0.8rem;
+  line-height: 1.5;
+  color: var(--color-text-muted);
+}
+
+.match-link {
+  display: block;
+  margin-top: 0.25rem;
+  color: var(--color-accent);
+  text-decoration: none;
+}
+
+.match-link:hover {
+  text-decoration: underline;
+}
+
+.vibe-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+@media (max-width: 560px) {
+  .match-columns {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/frontend/src/components/VisionToVibeDialog.vue
+++ b/frontend/src/components/VisionToVibeDialog.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { SoundFile } from '@/api/sounds'
 import type { VibeAnalysis, VibeMatch, VibeMatches } from '@/api/vision'
-import { computed, ref } from 'vue'
+import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { RouterLink } from 'vue-router'
 import { openFileDialog } from '@/api/config'
 import { getPathForFile } from '@/api/electron'
@@ -30,13 +30,37 @@ const error = ref<string | null>(null)
 const imageName = ref<string | null>(null)
 const dragOver = ref(false)
 
-const hasTaggedMusic = computed(() => props.musicSounds.some(s => (s.tags?.length ?? 0) > 0))
-const hasTaggedAmbience = computed(() => props.ambienceSounds.some(s => (s.tags?.length ?? 0) > 0))
-
-function isInScene(category: MatchCategory, soundId: string): boolean {
-  const ids = category === 'music' ? props.musicInScene : props.ambienceInScene
-  return ids.includes(soundId)
+interface MatchColumn {
+  category: MatchCategory
+  label: string
+  matches: VibeMatch[]
+  hasTaggedSounds: boolean
+  inScene: string[]
+  noMatchHint: string
 }
+
+function hasAnyTags(sounds: SoundFile[]): boolean {
+  return sounds.some(s => (s.tags?.length ?? 0) > 0)
+}
+
+const columns = computed<MatchColumn[]>(() => [
+  {
+    category: 'music',
+    label: 'Music',
+    matches: matches.value?.music ?? [],
+    hasTaggedSounds: hasAnyTags(props.musicSounds),
+    inScene: props.musicInScene,
+    noMatchHint: 'No Music matched these tags. Try tagging more tracks with moods and settings.',
+  },
+  {
+    category: 'ambience',
+    label: 'Ambience',
+    matches: matches.value?.ambience ?? [],
+    hasTaggedSounds: hasAnyTags(props.ambienceSounds),
+    inScene: props.ambienceInScene,
+    noMatchHint: 'No Ambience matched these tags. Try tagging more loops with moods and settings.',
+  },
+])
 
 function fileNameOf(path: string): string {
   return path.split(/[\\/]/).pop() ?? path
@@ -110,6 +134,14 @@ function reset() {
 function scoreLabel(match: VibeMatch): string {
   return `${match.score} ${match.score === 1 ? 'tag' : 'tags'} in common`
 }
+
+function onKeydown(e: KeyboardEvent) {
+  if (e.key === 'Escape')
+    emit('close')
+}
+
+onMounted(() => window.addEventListener('keydown', onKeydown))
+onUnmounted(() => window.removeEventListener('keydown', onKeydown))
 </script>
 
 <template>
@@ -183,12 +215,18 @@ function scoreLabel(match: VibeMatch): string {
           </section>
 
           <div class="match-columns">
-            <section class="match-column match-column-music" data-testid="vibe-music-matches">
+            <section
+              v-for="column in columns"
+              :key="column.category"
+              class="match-column"
+              :class="`match-column-${column.category}`"
+              :data-testid="`vibe-${column.category}-matches`"
+            >
               <h3 class="match-title">
-                Music
+                {{ column.label }}
               </h3>
-              <ul v-if="matches.music.length" class="match-list">
-                <li v-for="match in matches.music" :key="match.sound.id" class="match-item">
+              <ul v-if="column.matches.length" class="match-list">
+                <li v-for="match in column.matches" :key="match.sound.id" class="match-item">
                   <div class="match-info">
                     <span class="match-name" :title="match.sound.name">{{ match.sound.name }}</span>
                     <span class="match-score">{{ scoreLabel(match) }}</span>
@@ -196,52 +234,21 @@ function scoreLabel(match: VibeMatch): string {
                   <button
                     type="button"
                     class="btn-add-match"
-                    :disabled="isInScene('music', match.sound.id)"
-                    @click="emit('add', 'music', match.sound)"
+                    :disabled="column.inScene.includes(match.sound.id)"
+                    @click="emit('add', column.category, match.sound)"
                   >
-                    {{ isInScene('music', match.sound.id) ? '✓ Added' : '+ Add' }}
+                    {{ column.inScene.includes(match.sound.id) ? '✓ Added' : '+ Add' }}
                   </button>
                 </li>
               </ul>
-              <p v-else-if="!hasTaggedMusic" class="match-empty" data-testid="vibe-music-empty">
-                Tag your Music sounds to enable Vision-to-Vibe matching.
+              <p v-else-if="!column.hasTaggedSounds" class="match-empty" :data-testid="`vibe-${column.category}-empty`">
+                Tag your {{ column.label }} sounds to enable Vision-to-Vibe matching.
                 <RouterLink to="/media" class="match-link">
                   Open the sound library
                 </RouterLink>
               </p>
-              <p v-else class="match-empty" data-testid="vibe-music-empty">
-                No Music matched these tags. Try tagging more tracks with moods and settings.
-              </p>
-            </section>
-
-            <section class="match-column match-column-ambience" data-testid="vibe-ambience-matches">
-              <h3 class="match-title">
-                Ambience
-              </h3>
-              <ul v-if="matches.ambience.length" class="match-list">
-                <li v-for="match in matches.ambience" :key="match.sound.id" class="match-item">
-                  <div class="match-info">
-                    <span class="match-name" :title="match.sound.name">{{ match.sound.name }}</span>
-                    <span class="match-score">{{ scoreLabel(match) }}</span>
-                  </div>
-                  <button
-                    type="button"
-                    class="btn-add-match"
-                    :disabled="isInScene('ambience', match.sound.id)"
-                    @click="emit('add', 'ambience', match.sound)"
-                  >
-                    {{ isInScene('ambience', match.sound.id) ? '✓ Added' : '+ Add' }}
-                  </button>
-                </li>
-              </ul>
-              <p v-else-if="!hasTaggedAmbience" class="match-empty" data-testid="vibe-ambience-empty">
-                Tag your Ambience sounds to enable Vision-to-Vibe matching.
-                <RouterLink to="/media" class="match-link">
-                  Open the sound library
-                </RouterLink>
-              </p>
-              <p v-else class="match-empty" data-testid="vibe-ambience-empty">
-                No Ambience matched these tags. Try tagging more loops with moods and settings.
+              <p v-else class="match-empty" :data-testid="`vibe-${column.category}-empty`">
+                {{ column.noMatchHint }}
               </p>
             </section>
           </div>

--- a/frontend/src/views/SceneView.spec.ts
+++ b/frontend/src/views/SceneView.spec.ts
@@ -2,6 +2,7 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { createPinia } from 'pinia'
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createMemoryHistory, createRouter } from 'vue-router'
+import { fetchVisionConfig } from '@/api/config'
 import SceneView from './SceneView.vue'
 
 vi.mock('@/api/scenes', () => ({
@@ -30,8 +31,14 @@ vi.mock('@/api/audio-stream', () => ({
 }))
 
 vi.mock('@/api/config', () => ({
+  fetchVisionConfig: vi.fn().mockResolvedValue({ apiKeyConfigured: false, enabled: false }),
   openFileDialog: vi.fn().mockResolvedValue(null),
   saveFileDialog: vi.fn().mockResolvedValue(null),
+}))
+
+vi.mock('@/api/vision', () => ({
+  analyzeImageVibe: vi.fn(),
+  matchVibe: vi.fn(),
 }))
 
 vi.mock('@/audio/browser-audio-capture', () => ({
@@ -131,5 +138,46 @@ describe('sceneView pulses', () => {
     await wrapper.find('.btn-stop-scene').trigger('click')
     await flushPromises()
     expect(wrapper.find('.sound-card-ambience').classes()).not.toContain('pulse-breathe')
+  })
+})
+
+describe('sceneView — Vision to Vibe entry point', () => {
+  beforeEach(async () => {
+    const { getScene } = await import('@/api/scenes')
+    vi.mocked(getScene).mockResolvedValue(JSON.parse(JSON.stringify(scene)))
+    vi.mocked(fetchVisionConfig).mockReset()
+  })
+
+  it('is hidden when neither key nor toggle is set', async () => {
+    vi.mocked(fetchVisionConfig).mockResolvedValue({ apiKeyConfigured: false, enabled: false })
+    const wrapper = await mountScene()
+    expect(wrapper.find('[data-testid="vision-to-vibe-open"]').exists()).toBe(false)
+  })
+
+  it('is hidden when a key is set but the toggle is off', async () => {
+    vi.mocked(fetchVisionConfig).mockResolvedValue({ apiKeyConfigured: true, enabled: false })
+    const wrapper = await mountScene()
+    expect(wrapper.find('[data-testid="vision-to-vibe-open"]').exists()).toBe(false)
+  })
+
+  it('is hidden when the toggle is on but no key is set', async () => {
+    vi.mocked(fetchVisionConfig).mockResolvedValue({ apiKeyConfigured: false, enabled: true })
+    const wrapper = await mountScene()
+    expect(wrapper.find('[data-testid="vision-to-vibe-open"]').exists()).toBe(false)
+  })
+
+  it('is shown when both key and toggle are set, and opens the dialog', async () => {
+    vi.mocked(fetchVisionConfig).mockResolvedValue({ apiKeyConfigured: true, enabled: true })
+    const wrapper = await mountScene()
+    const button = wrapper.find('[data-testid="vision-to-vibe-open"]')
+    expect(button.exists()).toBe(true)
+    await button.trigger('click')
+    expect(wrapper.find('[role="dialog"][aria-label="Vision to Vibe"]').exists()).toBe(true)
+  })
+
+  it('stays hidden when the vision config cannot be loaded', async () => {
+    vi.mocked(fetchVisionConfig).mockRejectedValue(new Error('offline'))
+    const wrapper = await mountScene()
+    expect(wrapper.find('[data-testid="vision-to-vibe-open"]').exists()).toBe(false)
   })
 })

--- a/frontend/src/views/SceneView.vue
+++ b/frontend/src/views/SceneView.vue
@@ -12,7 +12,7 @@ import {
   stopAudioStream,
   stopEffectStream,
 } from '@/api/audio-stream'
-import { openFileDialog, saveFileDialog } from '@/api/config'
+import { fetchVisionConfig, openFileDialog, saveFileDialog } from '@/api/config'
 import { deleteScene, exportScene, getScene, importScene, listScenes, saveScene } from '@/api/scenes'
 import { listAmbience, listEffects, listMusic, soundStreamUrl } from '@/api/sounds'
 import {
@@ -20,6 +20,7 @@ import {
 } from '@/audio/browser-audio-capture'
 import RegistryBrowser from '@/components/RegistryBrowser.vue'
 import ResolveSoundDialog from '@/components/ResolveSoundDialog.vue'
+import VisionToVibeDialog from '@/components/VisionToVibeDialog.vue'
 import { useFlashSet } from '@/composables/useFlashSet'
 import { usePlayerStore } from '@/stores/player'
 
@@ -41,6 +42,8 @@ const createSceneBusy = ref(false)
 const exportBusy = ref(false)
 const importBusy = ref(false)
 const showRegistryBrowser = ref(false)
+const visionAvailable = ref(false)
+const showVisionDialog = ref(false)
 const resolveTarget = ref<{ category: 'ambience' | 'music' | 'effects', item: SceneItem } | null>(null)
 const loadError = ref<string | null>(null)
 const exportImportMessage = ref<{ type: 'success' | 'error', text: string } | null>(null)
@@ -175,6 +178,16 @@ async function loadScene() {
   }
   catch (err) {
     loadError.value = err instanceof Error ? err.message : 'Couldn\'t load this scene. Try again.'
+  }
+}
+
+async function loadVisionAvailability() {
+  try {
+    const config = await fetchVisionConfig()
+    visionAvailable.value = config.enabled && config.apiKeyConfigured
+  }
+  catch {
+    visionAvailable.value = false
   }
 }
 
@@ -638,12 +651,14 @@ async function onRegistryInstalled(sceneId: string) {
 onMounted(() => {
   loadScenes()
   loadSounds()
+  loadVisionAvailability()
 })
 
 onActivated(() => {
   loadScenes()
   loadSounds()
   loadScene()
+  loadVisionAvailability()
 })
 
 watch(sceneId, (newId, oldId) => {
@@ -775,6 +790,17 @@ watch(sceneId, (newId, oldId) => {
             {{ scene?.name ?? 'Loading…' }}
           </h1>
           <div v-if="scene" class="detail-actions">
+            <button
+              v-if="visionAvailable"
+              type="button"
+              class="btn btn-ghost btn-vision"
+              data-testid="vision-to-vibe-open"
+              title="Drop in an image and get matching Music and Ambience from your tagged library"
+              @click="showVisionDialog = true"
+            >
+              <span class="btn-vision-icon" aria-hidden="true">✦</span>
+              Vision to Vibe
+            </button>
             <button
               type="button"
               class="btn btn-ghost"
@@ -1133,6 +1159,16 @@ watch(sceneId, (newId, oldId) => {
       v-if="showRegistryBrowser"
       @close="showRegistryBrowser = false"
       @installed="onRegistryInstalled"
+    />
+
+    <VisionToVibeDialog
+      v-if="showVisionDialog && scene"
+      :music-sounds="musicSounds"
+      :ambience-sounds="ambienceSounds"
+      :music-in-scene="scene.music.map(m => m.soundId)"
+      :ambience-in-scene="scene.ambience.map(a => a.soundId)"
+      @add="addToScene"
+      @close="showVisionDialog = false"
     />
 
     <ResolveSoundDialog
@@ -1780,6 +1816,23 @@ watch(sceneId, (newId, oldId) => {
 
 .btn-danger:hover {
   color: var(--color-error);
+}
+
+.btn-vision {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border-color: var(--color-accent-muted);
+  color: var(--color-accent-hover);
+}
+
+.btn-vision:hover:not(:disabled) {
+  background: var(--color-accent-muted);
+  color: var(--color-accent-hover);
+}
+
+.btn-vision-icon {
+  font-size: 0.85em;
 }
 
 /* ── Narrow ── */

--- a/frontend/src/views/SettingsView.spec.ts
+++ b/frontend/src/views/SettingsView.spec.ts
@@ -1,18 +1,32 @@
 import { flushPromises, mount } from '@vue/test-utils'
 import { createPinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  fetchVisionConfig,
+  updateVisionApiKey,
+  updateVisionEnabled,
+} from '@/api/config'
 import { useAccessibilityStore } from '@/stores/accessibility'
 import SettingsView from './SettingsView.vue'
 
 vi.mock('@/api/config', () => ({
   fetchDiscordConfig: vi.fn().mockResolvedValue({ tokenConfigured: false }),
   fetchStoragePath: vi.fn().mockResolvedValue({ path: null }),
+  fetchVisionConfig: vi.fn().mockResolvedValue({ apiKeyConfigured: false, enabled: false }),
   selectStorageFolder: vi.fn(),
   updateDiscordToken: vi.fn().mockResolvedValue({ tokenConfigured: true }),
   updateStoragePath: vi.fn().mockResolvedValue(undefined),
   fetchAccessibilitySettings: vi.fn().mockResolvedValue({ luminancePulses: true, reduceMotion: null }),
   updateAccessibilitySettings: vi.fn().mockResolvedValue(undefined),
+  updateVisionApiKey: vi.fn().mockResolvedValue({ apiKeyConfigured: true, enabled: false }),
+  updateVisionEnabled: vi.fn().mockResolvedValue({ apiKeyConfigured: true, enabled: true }),
 }))
+
+function mountSettings() {
+  return mount(SettingsView, {
+    global: { plugins: [createPinia()] },
+  })
+}
 
 function stubMatchMedia(matches: boolean) {
   window.matchMedia = vi.fn().mockReturnValue({
@@ -119,6 +133,48 @@ describe('settingsView', () => {
       expect(updateAccessibilitySettings).toHaveBeenLastCalledWith({ luminancePulses: true, reduceMotion: null })
       expect(store.followsSystemMotion).toBe(true)
       expect(wrapper.find<HTMLInputElement>('#reduce-motion').element.checked).toBe(true)
+    })
+  })
+
+  describe('vision to Vibe section', () => {
+    beforeEach(() => {
+      vi.mocked(fetchVisionConfig).mockResolvedValue({ apiKeyConfigured: false, enabled: false })
+    })
+
+    it('renders the section with a third-party disclosure', async () => {
+      const wrapper = mountSettings()
+      await flushPromises()
+      const headings = wrapper.findAll('h2')
+      expect(headings.some(h => h.text() === 'Vision to Vibe')).toBe(true)
+      expect(wrapper.text()).toContain('Anthropic')
+    })
+
+    it('saves the API key', async () => {
+      const wrapper = mountSettings()
+      await flushPromises()
+      await wrapper.find('#vision-api-key').setValue('sk-ant-123')
+      await wrapper.find('[data-testid="vision-save-key"]').trigger('click')
+      await flushPromises()
+      expect(updateVisionApiKey).toHaveBeenCalledWith('sk-ant-123')
+      expect(wrapper.text()).toContain('Key saved')
+    })
+
+    it('shows the toggle disabled until a key is configured', async () => {
+      const wrapper = mountSettings()
+      await flushPromises()
+      const toggle = wrapper.find<HTMLInputElement>('#vision-enabled')
+      expect(toggle.element.disabled).toBe(true)
+    })
+
+    it('toggles the feature on when a key is configured', async () => {
+      vi.mocked(fetchVisionConfig).mockResolvedValue({ apiKeyConfigured: true, enabled: false })
+      const wrapper = mountSettings()
+      await flushPromises()
+      const toggle = wrapper.find<HTMLInputElement>('#vision-enabled')
+      expect(toggle.element.disabled).toBe(false)
+      await toggle.setValue(true)
+      await flushPromises()
+      expect(updateVisionEnabled).toHaveBeenCalledWith(true)
     })
   })
 })

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -1,11 +1,15 @@
 <script setup lang="ts">
+import type { VisionConfig } from '@/api/config'
 import { onMounted, ref } from 'vue'
 import {
   fetchDiscordConfig,
   fetchStoragePath,
+  fetchVisionConfig,
   selectStorageFolder,
   updateDiscordToken,
   updateStoragePath,
+  updateVisionApiKey,
+  updateVisionEnabled,
 } from '@/api/config'
 import { useAccessibilityStore } from '@/stores/accessibility'
 import { usePlayerStore } from '@/stores/player'
@@ -23,14 +27,22 @@ const storageMessage = ref<{ type: 'success' | 'error', text: string } | null>(n
 
 const accessibilityMessage = ref<{ type: 'success' | 'error', text: string } | null>(null)
 
+const visionConfig = ref<VisionConfig | null>(null)
+const visionKeyInput = ref('')
+const savingVisionKey = ref(false)
+const savingVisionToggle = ref(false)
+const visionMessage = ref<{ type: 'success' | 'error', text: string } | null>(null)
+
 async function load() {
   try {
-    const [config, storage] = await Promise.all([
+    const [config, storage, vision] = await Promise.all([
       fetchDiscordConfig(),
       fetchStoragePath().catch(() => ({ path: null })),
+      fetchVisionConfig().catch(() => ({ apiKeyConfigured: false, enabled: false })),
     ])
     discordConfig.value = config
     storagePath.value = storage.path
+    visionConfig.value = vision
   }
   catch (e) {
     message.value = { type: 'error', text: e instanceof Error ? e.message : 'Couldn\'t load settings. Try again.' }
@@ -130,6 +142,67 @@ function onReduceMotionChange(event: Event) {
 
 function useSystemMotion() {
   persistAccessibility(() => accessibility.setReduceMotion(null))
+}
+
+async function saveVisionKey() {
+  const apiKey = visionKeyInput.value.trim()
+  if (!apiKey) {
+    visionMessage.value = { type: 'error', text: 'Paste your Anthropic API key in the field first.' }
+    return
+  }
+  savingVisionKey.value = true
+  visionMessage.value = null
+  try {
+    visionConfig.value = await updateVisionApiKey(apiKey)
+    visionKeyInput.value = ''
+    visionMessage.value = { type: 'success', text: 'Key saved. Switch Vision to Vibe on below to start using it.' }
+  }
+  catch (e) {
+    visionMessage.value = { type: 'error', text: e instanceof Error ? e.message : 'Couldn\'t save the API key.' }
+  }
+  finally {
+    savingVisionKey.value = false
+  }
+}
+
+async function clearVisionKey() {
+  savingVisionKey.value = true
+  visionMessage.value = null
+  try {
+    visionConfig.value = await updateVisionApiKey('')
+    if (visionConfig.value.apiKeyConfigured) {
+      visionMessage.value = { type: 'success', text: 'Stored key removed. The key from the HIBIKI_VISION_API_KEY environment variable is still in use.' }
+      return
+    }
+    if (visionConfig.value.enabled)
+      visionConfig.value = await updateVisionEnabled(false)
+    visionMessage.value = { type: 'success', text: 'Key removed. Vision to Vibe is off.' }
+  }
+  catch (e) {
+    visionMessage.value = { type: 'error', text: e instanceof Error ? e.message : 'Couldn\'t remove the API key.' }
+  }
+  finally {
+    savingVisionKey.value = false
+  }
+}
+
+async function toggleVision(event: Event) {
+  const enabled = (event.target as HTMLInputElement).checked
+  savingVisionToggle.value = true
+  visionMessage.value = null
+  try {
+    visionConfig.value = await updateVisionEnabled(enabled)
+    visionMessage.value = {
+      type: 'success',
+      text: enabled ? 'Vision to Vibe is on. Look for it in the scene editor.' : 'Vision to Vibe is off.',
+    }
+  }
+  catch (e) {
+    visionMessage.value = { type: 'error', text: e instanceof Error ? e.message : 'Couldn\'t update Vision to Vibe.' }
+  }
+  finally {
+    savingVisionToggle.value = false
+  }
 }
 
 onMounted(load)
@@ -317,6 +390,82 @@ onMounted(load)
         {{ accessibilityMessage.text }}
       </p>
     </section>
+
+    <hr class="divider">
+
+    <section class="section">
+      <div class="section-header">
+        <h2 class="section-title">
+          Vision to Vibe
+        </h2>
+        <p v-if="visionConfig" class="section-status">
+          <span v-if="visionConfig.enabled && visionConfig.apiKeyConfigured" class="status-connected">On</span>
+          <span v-else-if="visionConfig.apiKeyConfigured" class="status-missing">Key saved, switched off</span>
+          <span v-else class="status-missing">No key yet</span>
+        </p>
+      </div>
+      <p class="section-desc">
+        Drop a battle map or mood-board image into a scene and get matching Music and Ambience suggestions from your own tagged sound library.
+        <strong class="privacy-note">Opt-in: each image you analyze is sent to Anthropic's Claude API using your key.</strong>
+        Hibiki does not keep the image after the request. Off by default.
+      </p>
+      <div class="field">
+        <label for="vision-api-key" class="field-label">Anthropic API key</label>
+        <div class="field-row">
+          <input
+            id="vision-api-key"
+            v-model="visionKeyInput"
+            type="password"
+            :placeholder="visionConfig?.apiKeyConfigured ? 'Key saved — paste a new key to replace it' : 'Paste your Anthropic API key'"
+            autocomplete="off"
+            class="input field-input"
+          >
+          <button
+            type="button"
+            class="btn btn-primary"
+            data-testid="vision-save-key"
+            :disabled="savingVisionKey || !visionKeyInput.trim()"
+            @click="saveVisionKey"
+          >
+            {{ savingVisionKey ? 'Saving…' : 'Save' }}
+          </button>
+          <button
+            v-if="visionConfig?.apiKeyConfigured"
+            type="button"
+            class="btn btn-ghost"
+            :disabled="savingVisionKey"
+            @click="clearVisionKey"
+          >
+            Remove
+          </button>
+        </div>
+      </div>
+      <div class="toggle-list vision-toggle-list">
+        <div class="toggle-row" :class="{ 'toggle-row-disabled': !visionConfig?.apiKeyConfigured }">
+          <input
+            id="vision-enabled"
+            type="checkbox"
+            class="toggle-input"
+            :checked="Boolean(visionConfig?.enabled)"
+            :disabled="!visionConfig?.apiKeyConfigured || savingVisionToggle"
+            @change="toggleVision"
+          >
+          <div class="toggle-text">
+            <label for="vision-enabled" class="toggle-title">Enable Vision to Vibe</label>
+            <span class="toggle-desc">
+              {{ visionConfig?.apiKeyConfigured ? 'Shows the Vision to Vibe button in the scene editor.' : 'Save an API key first.' }}
+            </span>
+          </div>
+        </div>
+      </div>
+      <p
+        v-if="visionMessage"
+        class="status-message settings-message"
+        :class="[visionMessage.type === 'success' ? 'status-message-success' : 'status-message-error']"
+      >
+        {{ visionMessage.text }}
+      </p>
+    </section>
   </div>
 </template>
 
@@ -480,6 +629,27 @@ onMounted(load)
 
 .btn-motion-reset:hover {
   text-decoration: underline;
+}
+
+/* ── Vision to Vibe ── */
+
+.privacy-note {
+  display: block;
+  margin-top: 0.5rem;
+  color: var(--color-text);
+  font-weight: 600;
+}
+
+.vision-toggle-list {
+  margin-top: 1rem;
+}
+
+.toggle-row-disabled {
+  opacity: 0.6;
+}
+
+.toggle-row-disabled .toggle-title {
+  cursor: not-allowed;
 }
 
 /* ── Buttons ── */

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "docs": "cd docs && bundle exec jekyll serve --baseurl \"\" --livereload"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.117.1",
     "@discordjs/opus": "^0.10.0",
     "@discordjs/rest": "^2.3.0",
     "@discordjs/voice": "^0.19.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
 
   .:
     dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.117.1
+        version: 0.117.1
       '@discordjs/opus':
         specifier: ^0.10.0
         version: 0.10.0(encoding@0.1.13)(supports-color@8.1.1)
@@ -222,6 +225,15 @@ packages:
 
   '@antfu/install-pkg@2.0.1':
     resolution: {integrity: sha512-iCKVQcIC0e3oDxEfs3SHQGW+ovhBMZmS1TE+bTk50rVyMCBmCfClv7Qi3HQKlumYwvjb/iIMeWCW2i67q6kFfQ==}
+
+  '@anthropic-ai/sdk@0.117.1':
+    resolution: {integrity: sha512-Yn2QlXfyCiKJ5YGCOOay7ZE78ISvII2XY621WMCiflmG8IYgwx59IBwPExxki3Xk9jKUtnD/Sj6UvplWr0rZxg==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@asamuzakjp/css-color@6.0.7':
     resolution: {integrity: sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==}
@@ -464,6 +476,10 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/template@7.29.7':
     resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
@@ -1484,6 +1500,9 @@ packages:
   '@snazzah/davey@0.1.12':
     resolution: {integrity: sha512-V+NlX5931RwVamZhhEfZekMdcvXDKdMAmHW1AuGaykVQsNyBOq3bpmGpoKRBDCYgFWKIufJ0Dcg3m4cYhvUy6g==}
     engines: {node: '>= 10'}
+
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -3075,6 +3094,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fast-string-truncated-width@3.0.3:
     resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
 
@@ -3799,6 +3821,10 @@ packages:
   json-parse-even-better-errors@6.0.0:
     resolution: {integrity: sha512-2/8adwnK1/+Fdjyts4r6wSpfANWw8zdNhU9U/Llk59c6O+DjSisPWPykwoL8gZmocP9Dy64S7oie2g+Mia123A==}
     engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -5060,6 +5086,9 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
@@ -5294,6 +5323,9 @@ packages:
   trim-repeated@1.0.0:
     resolution: {integrity: sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==}
     engines: {node: '>=0.10.0'}
+
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -5946,6 +5978,11 @@ snapshots:
       package-manager-detector: 1.8.0
       tinyexec: 1.3.0
 
+  '@anthropic-ai/sdk@0.117.1':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
+
   '@asamuzakjp/css-color@6.0.7':
     dependencies:
       '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
@@ -6230,6 +6267,8 @@ snapshots:
       '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
     transitivePeerDependencies:
       - supports-color
+
+  '@babel/runtime@7.29.7': {}
 
   '@babel/template@7.29.7':
     dependencies:
@@ -7573,6 +7612,8 @@ snapshots:
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
+
+  '@stablelib/base64@1.0.1': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -9385,6 +9426,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-sha256@1.3.0: {}
+
   fast-string-truncated-width@3.0.3: {}
 
   fast-string-width@3.0.2:
@@ -10349,6 +10392,11 @@ snapshots:
   json-parse-even-better-errors@2.3.1: {}
 
   json-parse-even-better-errors@6.0.0: {}
+
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      ts-algebra: 2.0.0
 
   json-schema-traverse@0.4.1: {}
 
@@ -11724,6 +11772,11 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   std-env@4.1.0: {}
 
   stream-buffers@2.2.0:
@@ -11921,6 +11974,8 @@ snapshots:
   trim-repeated@1.0.0:
     dependencies:
       escape-string-regexp: 1.0.5
+
+  ts-algebra@2.0.0: {}
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:

--- a/src/bootstrap-embedded.ts
+++ b/src/bootstrap-embedded.ts
@@ -1,7 +1,8 @@
 import type { VoiceBasedChannel } from 'discord.js'
 import type { AccessibilitySettings } from './config/accessibility-settings'
 import type { SoundCategory } from './sound/sound.types'
-import type { VibeMatch } from './vision/vibe-matching'
+import type { VibeMatches } from './vision/vibe-matching'
+import type { VisionSettingsState } from './vision/vision-settings'
 import type { VibeAnalysis } from './vision/vision.service'
 import { mkdir } from 'node:fs/promises'
 import { dirname } from 'node:path'
@@ -16,7 +17,8 @@ import { importScene } from './scenes/scene-import'
 import { createSceneRegistry } from './scenes/scene-registry'
 import { createSceneStore } from './scenes/scene-store'
 import { createSoundLibrary } from './sound/sound-library'
-import { matchVibeTags } from './vision/vibe-matching'
+import { matchVibeLibrary } from './vision/vibe-matching'
+import { createVisionSettings } from './vision/vision-settings'
 import { createVisionService } from './vision/vision.service'
 
 async function ensureStorageDirs(config: ReturnType<typeof getConfig>): Promise<void> {
@@ -70,9 +72,9 @@ export interface EmbeddedApi {
     setBookmarks: (bookmarks: { name: string, url: string, favicon?: string }[]) => Promise<void>
     getAccessibility: () => Promise<AccessibilitySettings>
     setAccessibility: (settings: AccessibilitySettings) => Promise<void>
-    getVision: () => Promise<VisionConfig>
-    setVisionApiKey: (apiKey: string) => Promise<VisionConfig>
-    setVisionEnabled: (enabled: boolean) => Promise<VisionConfig>
+    getVision: () => Promise<VisionSettingsState>
+    setVisionApiKey: (apiKey: string) => Promise<VisionSettingsState>
+    setVisionEnabled: (enabled: boolean) => Promise<VisionSettingsState>
   }
   sounds: {
     listMusic: () => ReturnType<ReturnType<typeof createSoundLibrary>['list']>
@@ -101,19 +103,6 @@ export interface EmbeddedApi {
   }
 }
 
-export interface VisionConfig {
-  apiKeyConfigured: boolean
-  enabled: boolean
-}
-
-export interface VibeMatches {
-  music: VibeMatch[]
-  ambience: VibeMatch[]
-}
-
-const VISION_API_KEY_CONFIG_KEY = 'vision.apiKey'
-const VISION_ENABLED_CONFIG_KEY = 'vision.enabled'
-
 export interface EmbeddedApp {
   close: () => Promise<void>
   api: EmbeddedApi
@@ -132,16 +121,8 @@ export async function getEmbeddedApp(): Promise<EmbeddedApp> {
   const discord = createDiscordClient(config, appConfig)
   const player = createPlayer(discord)
 
-  const getVisionApiKey = async (): Promise<string | null> => {
-    if (config.vision.apiKey)
-      return config.vision.apiKey
-    return appConfig.get(VISION_API_KEY_CONFIG_KEY)
-  }
-  const getVisionConfig = async (): Promise<VisionConfig> => {
-    const [apiKey, enabled] = await Promise.all([getVisionApiKey(), appConfig.get(VISION_ENABLED_CONFIG_KEY)])
-    return { apiKeyConfigured: Boolean(apiKey?.trim()), enabled: enabled === 'true' }
-  }
-  const vision = createVisionService({ getApiKey: getVisionApiKey })
+  const visionSettings = createVisionSettings(config, appConfig)
+  const vision = createVisionService({ getApiKey: visionSettings.getApiKey })
 
   // Defer login to avoid blocking app startup
   // Discord will connect in background after main window shows
@@ -220,15 +201,9 @@ export async function getEmbeddedApp(): Promise<EmbeddedApp> {
       setAccessibility: async (settings) => {
         await appConfig.set('accessibility', JSON.stringify(normalizeAccessibilitySettings(settings)))
       },
-      getVision: () => getVisionConfig(),
-      setVisionApiKey: async (apiKey) => {
-        await appConfig.set(VISION_API_KEY_CONFIG_KEY, typeof apiKey === 'string' ? apiKey.trim() : '')
-        return getVisionConfig()
-      },
-      setVisionEnabled: async (enabled) => {
-        await appConfig.set(VISION_ENABLED_CONFIG_KEY, enabled ? 'true' : 'false')
-        return getVisionConfig()
-      },
+      getVision: () => visionSettings.get(),
+      setVisionApiKey: apiKey => visionSettings.setApiKey(apiKey),
+      setVisionEnabled: enabled => visionSettings.setEnabled(enabled),
     },
     sounds: {
       listMusic: () => sounds.list('music'),
@@ -260,17 +235,14 @@ export async function getEmbeddedApp(): Promise<EmbeddedApp> {
     },
     vision: {
       analyzeImageVibe: async (imagePath) => {
-        const { enabled } = await getVisionConfig()
+        const { enabled } = await visionSettings.get()
         if (!enabled)
           throw new Error('Vision to Vibe is turned off. Enable it in Settings first.')
         return vision.analyzeImageVibe(imagePath)
       },
       matchVibe: async (vibeTags) => {
         const [music, ambience] = await Promise.all([sounds.list('music'), sounds.list('ambience')])
-        return {
-          music: matchVibeTags(vibeTags, music),
-          ambience: matchVibeTags(vibeTags, ambience),
-        }
+        return matchVibeLibrary(vibeTags, { music, ambience })
       },
     },
   }

--- a/src/bootstrap-embedded.ts
+++ b/src/bootstrap-embedded.ts
@@ -1,6 +1,8 @@
 import type { VoiceBasedChannel } from 'discord.js'
 import type { AccessibilitySettings } from './config/accessibility-settings'
 import type { SoundCategory } from './sound/sound.types'
+import type { VibeMatch } from './vision/vibe-matching'
+import type { VibeAnalysis } from './vision/vision.service'
 import { mkdir } from 'node:fs/promises'
 import { dirname } from 'node:path'
 import { generateDependencyReport } from '@discordjs/voice'
@@ -14,6 +16,8 @@ import { importScene } from './scenes/scene-import'
 import { createSceneRegistry } from './scenes/scene-registry'
 import { createSceneStore } from './scenes/scene-store'
 import { createSoundLibrary } from './sound/sound-library'
+import { matchVibeTags } from './vision/vibe-matching'
+import { createVisionService } from './vision/vision.service'
 
 async function ensureStorageDirs(config: ReturnType<typeof getConfig>): Promise<void> {
   const dbPath = config.database.path
@@ -66,6 +70,9 @@ export interface EmbeddedApi {
     setBookmarks: (bookmarks: { name: string, url: string, favicon?: string }[]) => Promise<void>
     getAccessibility: () => Promise<AccessibilitySettings>
     setAccessibility: (settings: AccessibilitySettings) => Promise<void>
+    getVision: () => Promise<VisionConfig>
+    setVisionApiKey: (apiKey: string) => Promise<VisionConfig>
+    setVisionEnabled: (enabled: boolean) => Promise<VisionConfig>
   }
   sounds: {
     listMusic: () => ReturnType<ReturnType<typeof createSoundLibrary>['list']>
@@ -74,6 +81,7 @@ export interface EmbeddedApi {
     uploadSound: (type: SoundCategory, buffer: Buffer, originalname: string) => ReturnType<ReturnType<typeof createSoundLibrary>['save']>
     deleteSound: (type: SoundCategory, id: string) => ReturnType<ReturnType<typeof createSoundLibrary>['remove']>
     getFilePath: (type: SoundCategory, id: string) => ReturnType<ReturnType<typeof createSoundLibrary>['getFilePath']>
+    setTags: (type: SoundCategory, id: string, tags: string[]) => ReturnType<ReturnType<typeof createSoundLibrary>['setTags']>
   }
   scenes: {
     list: () => ReturnType<ReturnType<typeof createSceneStore>['list']>
@@ -87,7 +95,24 @@ export interface EmbeddedApi {
     getIndex: (forceRefresh?: boolean) => Promise<import('./scenes/scene-package.types').RegistryIndex>
     installFromRegistry: (slug: string) => Promise<import('./scenes/scene-store').Scene>
   }
+  vision: {
+    analyzeImageVibe: (imagePath: string) => Promise<VibeAnalysis>
+    matchVibe: (vibeTags: string[]) => Promise<VibeMatches>
+  }
 }
+
+export interface VisionConfig {
+  apiKeyConfigured: boolean
+  enabled: boolean
+}
+
+export interface VibeMatches {
+  music: VibeMatch[]
+  ambience: VibeMatch[]
+}
+
+const VISION_API_KEY_CONFIG_KEY = 'vision.apiKey'
+const VISION_ENABLED_CONFIG_KEY = 'vision.enabled'
 
 export interface EmbeddedApp {
   close: () => Promise<void>
@@ -106,6 +131,17 @@ export async function getEmbeddedApp(): Promise<EmbeddedApp> {
   const registry = createSceneRegistry(config)
   const discord = createDiscordClient(config, appConfig)
   const player = createPlayer(discord)
+
+  const getVisionApiKey = async (): Promise<string | null> => {
+    if (config.vision.apiKey)
+      return config.vision.apiKey
+    return appConfig.get(VISION_API_KEY_CONFIG_KEY)
+  }
+  const getVisionConfig = async (): Promise<VisionConfig> => {
+    const [apiKey, enabled] = await Promise.all([getVisionApiKey(), appConfig.get(VISION_ENABLED_CONFIG_KEY)])
+    return { apiKeyConfigured: Boolean(apiKey?.trim()), enabled: enabled === 'true' }
+  }
+  const vision = createVisionService({ getApiKey: getVisionApiKey })
 
   // Defer login to avoid blocking app startup
   // Discord will connect in background after main window shows
@@ -184,6 +220,15 @@ export async function getEmbeddedApp(): Promise<EmbeddedApp> {
       setAccessibility: async (settings) => {
         await appConfig.set('accessibility', JSON.stringify(normalizeAccessibilitySettings(settings)))
       },
+      getVision: () => getVisionConfig(),
+      setVisionApiKey: async (apiKey) => {
+        await appConfig.set(VISION_API_KEY_CONFIG_KEY, typeof apiKey === 'string' ? apiKey.trim() : '')
+        return getVisionConfig()
+      },
+      setVisionEnabled: async (enabled) => {
+        await appConfig.set(VISION_ENABLED_CONFIG_KEY, enabled ? 'true' : 'false')
+        return getVisionConfig()
+      },
     },
     sounds: {
       listMusic: () => sounds.list('music'),
@@ -199,6 +244,7 @@ export async function getEmbeddedApp(): Promise<EmbeddedApp> {
         await scenes.removeSoundFromAll(type, id)
       },
       getFilePath: (type, id) => sounds.getFilePath(type, id),
+      setTags: (type, id, tags) => sounds.setTags(type, id, Array.isArray(tags) ? tags : []),
     },
     scenes: {
       list: () => scenes.list(),
@@ -211,6 +257,21 @@ export async function getEmbeddedApp(): Promise<EmbeddedApp> {
     registry: {
       getIndex: forceRefresh => registry.fetchIndex(forceRefresh ?? false),
       installFromRegistry: slug => registry.installFromRegistry(slug),
+    },
+    vision: {
+      analyzeImageVibe: async (imagePath) => {
+        const { enabled } = await getVisionConfig()
+        if (!enabled)
+          throw new Error('Vision to Vibe is turned off. Enable it in Settings first.')
+        return vision.analyzeImageVibe(imagePath)
+      },
+      matchVibe: async (vibeTags) => {
+        const [music, ambience] = await Promise.all([sounds.list('music'), sounds.list('ambience')])
+        return {
+          music: matchVibeTags(vibeTags, music),
+          ambience: matchVibeTags(vibeTags, ambience),
+        }
+      },
     },
   }
 

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -25,6 +25,9 @@ export function configuration() {
     discord: {
       token: process.env.DISCORD_TOKEN ?? '',
     },
+    vision: {
+      apiKey: process.env.HIBIKI_VISION_API_KEY ?? '',
+    },
     audio: {
       storageRoot,
       musicDir,

--- a/src/sound/sound-library.spec.ts
+++ b/src/sound/sound-library.spec.ts
@@ -66,3 +66,87 @@ describe('createSoundLibrary', () => {
     expect(list).toHaveLength(0)
   })
 })
+
+describe('sound tags', () => {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'hibiki-sound-tags-'))
+  const musicDir = join(tempRoot, 'music')
+  const ambienceDir = join(tempRoot, 'ambience')
+  const config = {
+    discord: { token: '' },
+    vision: { apiKey: '' },
+    audio: {
+      storageRoot: tempRoot,
+      musicDir,
+      effectsDir: join(tempRoot, 'effects'),
+      ambienceDir,
+      webDistDir: 'web-dist',
+    },
+    database: { path: join(tempRoot, 'data', 'hibiki.json') },
+  }
+
+  beforeAll(async () => {
+    const { mkdir } = await import('node:fs/promises')
+    await mkdir(musicDir, { recursive: true })
+    await mkdir(ambienceDir, { recursive: true })
+    writeFileSync(join(musicDir, 'tavern.mp3'), 'data')
+    writeFileSync(join(ambienceDir, 'rain.mp3'), 'data')
+  })
+
+  it('tags default to an empty list for untagged sounds', async () => {
+    const lib = createSoundLibrary(config)
+    const list = await lib.list('music')
+    expect(list[0]!.tags).toEqual([])
+    const file = await lib.getFile('music', 'tavern')
+    expect(file.tags).toEqual([])
+  })
+
+  it('setTags persists tags and returns them from list() and getFile()', async () => {
+    const lib = createSoundLibrary(config)
+    await lib.setTags('music', 'tavern', ['warm', 'Candlelit'])
+    const list = await lib.list('music')
+    expect(list[0]!.tags).toEqual(['warm', 'Candlelit'])
+    const file = await lib.getFile('music', 'tavern')
+    expect(file.tags).toEqual(['warm', 'Candlelit'])
+  })
+
+  it('setTags normalizes whitespace and drops empty entries', async () => {
+    const lib = createSoundLibrary(config)
+    const saved = await lib.setTags('ambience', 'rain', ['  storm ', '', 'wet '])
+    expect(saved).toEqual(['storm', 'wet'])
+  })
+
+  it('setTags rejects unknown sounds', async () => {
+    const lib = createSoundLibrary(config)
+    await expect(lib.setTags('music', 'nope', ['x'])).rejects.toThrow(/not found/)
+  })
+
+  it('tags are scoped per category', async () => {
+    const lib = createSoundLibrary(config)
+    const ambience = await lib.list('ambience')
+    expect(ambience[0]!.tags).toEqual(['storm', 'wet'])
+    const music = await lib.list('music')
+    expect(music[0]!.tags).toEqual(['warm', 'Candlelit'])
+  })
+
+  it('tags survive across separate service instances', async () => {
+    const other = createSoundLibrary(config)
+    const file = await other.getFile('music', 'tavern')
+    expect(file.tags).toEqual(['warm', 'Candlelit'])
+  })
+
+  it('save() returns a sound with empty tags', async () => {
+    const lib = createSoundLibrary(config)
+    const saved = await lib.save('music', { buffer: Buffer.from('x'), originalname: 'new-song.mp3' })
+    expect(saved.tags).toEqual([])
+  })
+
+  it('remove() clears the tags of the deleted sound', async () => {
+    const lib = createSoundLibrary(config)
+    writeFileSync(join(ambienceDir, 'wind.mp3'), 'data')
+    await lib.setTags('ambience', 'wind', ['howling'])
+    await lib.remove('ambience', 'wind')
+    writeFileSync(join(ambienceDir, 'wind.mp3'), 'data')
+    const file = await lib.getFile('ambience', 'wind')
+    expect(file.tags).toEqual([])
+  })
+})

--- a/src/sound/sound-library.ts
+++ b/src/sound/sound-library.ts
@@ -4,6 +4,7 @@ import { mkdir, stat, unlink, writeFile } from 'node:fs/promises'
 import { extname, join } from 'node:path'
 import fg from 'fast-glob'
 import slugify from 'slugify'
+import { createSoundTagsStore } from './sound-tags.store'
 
 function resolvePath(config: Config, category: SoundCategory, filename?: string): string {
   const base = category === 'music'
@@ -39,6 +40,8 @@ function buildId(name: string): string {
 }
 
 export function createSoundLibrary(config: Config) {
+  const tagsStore = createSoundTagsStore(config)
+
   return {
     async list(category: SoundCategory): Promise<SoundFile[]> {
       const base = resolvePath(config, category)
@@ -49,18 +52,21 @@ export function createSoundLibrary(config: Config) {
       catch {
         return []
       }
+      const tagsById = await tagsStore.getAll(category)
       const results: SoundFile[] = []
       for (const file of entries) {
         const filePath = resolvePath(config, category, file)
         try {
           const stats = await stat(filePath)
+          const id = file.replace(extname(file), '')
           results.push({
-            id: file.replace(extname(file), ''),
+            id,
             name: humanize(file),
             filename: file,
             size: stats.size,
             category,
             createdAt: stats.birthtime.toISOString(),
+            tags: tagsById.get(id) ?? [],
           })
         }
         catch {
@@ -78,7 +84,7 @@ export function createSoundLibrary(config: Config) {
     async getFile(category: SoundCategory, id: string): Promise<SoundFile & { path: string }> {
       const filename = await findFilename(config, category, id)
       const path = resolvePath(config, category, filename)
-      const stats = await stat(path)
+      const [stats, tags] = await Promise.all([stat(path), tagsStore.get(category, id)])
       return {
         id,
         name: humanize(filename),
@@ -86,6 +92,7 @@ export function createSoundLibrary(config: Config) {
         category,
         size: stats.size,
         createdAt: stats.birthtime.toISOString(),
+        tags,
         path,
       }
     },
@@ -111,6 +118,12 @@ export function createSoundLibrary(config: Config) {
       const file = await findFilename(config, category, id)
       const path = resolvePath(config, category, file)
       await unlink(path)
+      await tagsStore.remove(category, id)
+    },
+
+    async setTags(category: SoundCategory, id: string, tags: string[]): Promise<string[]> {
+      await findFilename(config, category, id)
+      return tagsStore.set(category, id, tags)
     },
 
     async save(
@@ -136,6 +149,7 @@ export function createSoundLibrary(config: Config) {
         category,
         size: stats.size,
         createdAt: stats.birthtime.toISOString(),
+        tags: [],
       }
     },
   }

--- a/src/sound/sound-tags.store.ts
+++ b/src/sound/sound-tags.store.ts
@@ -1,0 +1,83 @@
+import type { Config } from '../config'
+import type { SoundCategory } from './sound.types'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname, join, resolve } from 'node:path'
+
+const TAGS_FILENAME = 'sound-tags.json'
+
+type TagsByKey = Record<string, string[]>
+
+function getTagsFilePath(config: Config): string {
+  const dir = resolve(process.cwd(), dirname(config.database.path))
+  return join(dir, TAGS_FILENAME)
+}
+
+function tagKey(category: SoundCategory, id: string): string {
+  return `${category}/${id}`
+}
+
+async function readData(filePath: string): Promise<TagsByKey> {
+  try {
+    const raw = await readFile(filePath, 'utf-8')
+    const data = JSON.parse(raw) as TagsByKey
+    return typeof data === 'object' && data !== null ? data : {}
+  }
+  catch {
+    return {}
+  }
+}
+
+async function writeData(filePath: string, data: TagsByKey): Promise<void> {
+  await mkdir(dirname(filePath), { recursive: true })
+  await writeFile(filePath, JSON.stringify(data, null, 2), 'utf-8')
+}
+
+export function normalizeTags(tags: string[]): string[] {
+  return tags.map(t => t.trim()).filter(t => t.length > 0)
+}
+
+export function createSoundTagsStore(config: Config) {
+  const filePath = getTagsFilePath(config)
+
+  return {
+    async getAll(category: SoundCategory): Promise<Map<string, string[]>> {
+      const data = await readData(filePath)
+      const prefix = `${category}/`
+      const result = new Map<string, string[]>()
+      for (const [key, tags] of Object.entries(data)) {
+        if (key.startsWith(prefix) && Array.isArray(tags))
+          result.set(key.slice(prefix.length), tags)
+      }
+      return result
+    },
+
+    async get(category: SoundCategory, id: string): Promise<string[]> {
+      const data = await readData(filePath)
+      const tags = data[tagKey(category, id)]
+      return Array.isArray(tags) ? tags : []
+    },
+
+    async set(category: SoundCategory, id: string, tags: string[]): Promise<string[]> {
+      const normalized = normalizeTags(tags)
+      const data = await readData(filePath)
+      const key = tagKey(category, id)
+      if (normalized.length === 0)
+        delete data[key]
+      else
+        data[key] = normalized
+      await writeData(filePath, data)
+      return normalized
+    },
+
+    async remove(category: SoundCategory, id: string): Promise<void> {
+      const data = await readData(filePath)
+      const key = tagKey(category, id)
+      if (key in data) {
+        delete data[key]
+        await writeData(filePath, data)
+      }
+    },
+  }
+}
+
+export type SoundTagsStore = ReturnType<typeof createSoundTagsStore>

--- a/src/sound/sound.types.ts
+++ b/src/sound/sound.types.ts
@@ -7,4 +7,5 @@ export interface SoundFile {
   size: number
   category: SoundCategory
   createdAt: string
+  tags: string[]
 }

--- a/src/vision/vibe-matching.spec.ts
+++ b/src/vision/vibe-matching.spec.ts
@@ -1,5 +1,5 @@
 import type { SoundFile } from '../sound/sound.types'
-import { matchVibeTags } from './vibe-matching'
+import { matchVibeLibrary, matchVibeTags } from './vibe-matching'
 
 function sound(id: string, tags: string[], createdAt = '2026-01-01T00:00:00.000Z', category: SoundFile['category'] = 'music'): SoundFile {
   return { id, name: id, filename: `${id}.mp3`, size: 1, category, createdAt, tags }
@@ -63,5 +63,22 @@ describe('matchVibeTags', () => {
   it('counts each vibe tag at most once per sound', () => {
     const sounds = [sound('multi', ['rain', 'rainy', 'raining'])]
     expect(matchVibeTags(['rain'], sounds)[0]!.score).toBe(1)
+  })
+})
+
+describe('matchVibeLibrary', () => {
+  it('scores Music and Ambience independently with their own caps', () => {
+    const music = Array.from({ length: 7 }, (_, i) => sound(`m${i}`, ['rain'], `2026-01-0${i + 1}T00:00:00.000Z`))
+    const ambience = [sound('a-hit', ['rain'], undefined, 'ambience'), sound('a-miss', ['desert'], undefined, 'ambience')]
+    const result = matchVibeLibrary(['rain'], { music, ambience })
+    expect(result.music).toHaveLength(5)
+    expect(result.music.every(m => m.sound.category === 'music')).toBe(true)
+    expect(result.ambience.map(m => m.sound.id)).toEqual(['a-hit'])
+  })
+
+  it('returns empty lists per category when nothing matches there', () => {
+    const result = matchVibeLibrary(['rain'], { music: [], ambience: [sound('a', ['rain'], undefined, 'ambience')] })
+    expect(result.music).toEqual([])
+    expect(result.ambience).toHaveLength(1)
   })
 })

--- a/src/vision/vibe-matching.spec.ts
+++ b/src/vision/vibe-matching.spec.ts
@@ -1,0 +1,67 @@
+import type { SoundFile } from '../sound/sound.types'
+import { matchVibeTags } from './vibe-matching'
+
+function sound(id: string, tags: string[], createdAt = '2026-01-01T00:00:00.000Z', category: SoundFile['category'] = 'music'): SoundFile {
+  return { id, name: id, filename: `${id}.mp3`, size: 1, category, createdAt, tags }
+}
+
+describe('matchVibeTags', () => {
+  it('ranks sounds by number of overlapping tags, highest first', () => {
+    const sounds = [
+      sound('one', ['tavern']),
+      sound('two', ['tavern', 'warm', 'candlelit']),
+      sound('three', ['tavern', 'warm']),
+    ]
+    const result = matchVibeTags(['tavern', 'warm', 'candlelit'], sounds)
+    expect(result.map(m => m.sound.id)).toEqual(['two', 'three', 'one'])
+    expect(result.map(m => m.score)).toEqual([3, 2, 1])
+  })
+
+  it('matches case-insensitively and by substring in either direction', () => {
+    const sounds = [
+      sound('storm', ['Stormy Coastline']),
+      sound('cave', ['dark']),
+    ]
+    const result = matchVibeTags(['stormy', 'Dark Cave'], sounds)
+    expect(result.map(m => m.sound.id).sort()).toEqual(['cave', 'storm'])
+  })
+
+  it('excludes sounds with zero overlap instead of ranking them last', () => {
+    const sounds = [sound('hit', ['forest']), sound('miss', ['desert'])]
+    const result = matchVibeTags(['forest'], sounds)
+    expect(result.map(m => m.sound.id)).toEqual(['hit'])
+  })
+
+  it('never matches sounds with empty tags', () => {
+    const sounds = [sound('untagged', []), sound('blank', ['   '])]
+    expect(matchVibeTags(['forest', 'rain'], sounds)).toEqual([])
+  })
+
+  it('returns nothing when the vibe tags are empty', () => {
+    expect(matchVibeTags([], [sound('a', ['forest'])])).toEqual([])
+    expect(matchVibeTags(['', '  '], [sound('a', ['forest'])])).toEqual([])
+  })
+
+  it('caps results at 5 by default', () => {
+    const sounds = Array.from({ length: 8 }, (_, i) => sound(`s${i}`, ['rain']))
+    expect(matchVibeTags(['rain'], sounds)).toHaveLength(5)
+  })
+
+  it('honours a custom limit', () => {
+    const sounds = Array.from({ length: 8 }, (_, i) => sound(`s${i}`, ['rain']))
+    expect(matchVibeTags(['rain'], sounds, 2)).toHaveLength(2)
+  })
+
+  it('breaks ties by most recently created', () => {
+    const sounds = [
+      sound('old', ['rain'], '2025-01-01T00:00:00.000Z'),
+      sound('new', ['rain'], '2026-01-01T00:00:00.000Z'),
+    ]
+    expect(matchVibeTags(['rain'], sounds).map(m => m.sound.id)).toEqual(['new', 'old'])
+  })
+
+  it('counts each vibe tag at most once per sound', () => {
+    const sounds = [sound('multi', ['rain', 'rainy', 'raining'])]
+    expect(matchVibeTags(['rain'], sounds)[0]!.score).toBe(1)
+  })
+})

--- a/src/vision/vibe-matching.ts
+++ b/src/vision/vibe-matching.ts
@@ -5,6 +5,16 @@ export interface VibeMatch {
   score: number
 }
 
+export interface VibeLibrary {
+  music: SoundFile[]
+  ambience: SoundFile[]
+}
+
+export interface VibeMatches {
+  music: VibeMatch[]
+  ambience: VibeMatch[]
+}
+
 export const DEFAULT_MATCH_LIMIT = 5
 
 function normalize(tag: string): string {
@@ -31,4 +41,12 @@ export function matchVibeTags(vibeTags: string[], sounds: SoundFile[], limit = D
     .filter(match => match.score > 0)
     .sort((a, b) => b.score - a.score || b.sound.createdAt.localeCompare(a.sound.createdAt))
     .slice(0, limit)
+}
+
+/** Ranks Music and Ambience independently — a strong match in one category never crowds out the other. */
+export function matchVibeLibrary(vibeTags: string[], library: VibeLibrary, limit = DEFAULT_MATCH_LIMIT): VibeMatches {
+  return {
+    music: matchVibeTags(vibeTags, library.music, limit),
+    ambience: matchVibeTags(vibeTags, library.ambience, limit),
+  }
 }

--- a/src/vision/vibe-matching.ts
+++ b/src/vision/vibe-matching.ts
@@ -1,0 +1,34 @@
+import type { SoundFile } from '../sound/sound.types'
+
+export interface VibeMatch {
+  sound: SoundFile
+  score: number
+}
+
+export const DEFAULT_MATCH_LIMIT = 5
+
+function normalize(tag: string): string {
+  return tag.trim().toLowerCase()
+}
+
+function overlaps(vibeTag: string, soundTag: string): boolean {
+  return vibeTag.includes(soundTag) || soundTag.includes(vibeTag)
+}
+
+function scoreSound(vibeTags: string[], sound: SoundFile): number {
+  const soundTags = sound.tags.map(normalize).filter(t => t.length > 0)
+  if (soundTags.length === 0)
+    return 0
+  return vibeTags.filter(vibeTag => soundTags.some(soundTag => overlaps(vibeTag, soundTag))).length
+}
+
+export function matchVibeTags(vibeTags: string[], sounds: SoundFile[], limit = DEFAULT_MATCH_LIMIT): VibeMatch[] {
+  const normalizedVibeTags = vibeTags.map(normalize).filter(t => t.length > 0)
+  if (normalizedVibeTags.length === 0)
+    return []
+  return sounds
+    .map(sound => ({ sound, score: scoreSound(normalizedVibeTags, sound) }))
+    .filter(match => match.score > 0)
+    .sort((a, b) => b.score - a.score || b.sound.createdAt.localeCompare(a.sound.createdAt))
+    .slice(0, limit)
+}

--- a/src/vision/vision-settings.spec.ts
+++ b/src/vision/vision-settings.spec.ts
@@ -1,0 +1,58 @@
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createAppConfig } from '../persistence'
+import { createVisionSettings } from './vision-settings'
+
+function makeConfig(apiKeyFromEnv: string) {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'hibiki-vision-settings-'))
+  return {
+    discord: { token: '' },
+    vision: { apiKey: apiKeyFromEnv },
+    audio: {
+      storageRoot: tempRoot,
+      musicDir: join(tempRoot, 'music'),
+      effectsDir: join(tempRoot, 'effects'),
+      ambienceDir: join(tempRoot, 'ambience'),
+      webDistDir: 'web-dist',
+    },
+    database: { path: join(tempRoot, 'data', 'hibiki.json') },
+  }
+}
+
+describe('createVisionSettings', () => {
+  it('starts with no key and the feature off', async () => {
+    const config = makeConfig('')
+    const settings = createVisionSettings(config, createAppConfig(config))
+    expect(await settings.get()).toEqual({ apiKeyConfigured: false, enabled: false })
+    expect(await settings.getApiKey()).toBeNull()
+  })
+
+  it('stores a trimmed key and reports it configured', async () => {
+    const config = makeConfig('')
+    const settings = createVisionSettings(config, createAppConfig(config))
+    expect(await settings.setApiKey('  sk-stored  ')).toEqual({ apiKeyConfigured: true, enabled: false })
+    expect(await settings.getApiKey()).toBe('sk-stored')
+  })
+
+  it('prefers the environment key over the stored one, like the Discord token', async () => {
+    const config = makeConfig('sk-env')
+    const settings = createVisionSettings(config, createAppConfig(config))
+    await settings.setApiKey('sk-stored')
+    expect(await settings.getApiKey()).toBe('sk-env')
+  })
+
+  it('clearing the stored key leaves the feature unconfigured', async () => {
+    const config = makeConfig('')
+    const settings = createVisionSettings(config, createAppConfig(config))
+    await settings.setApiKey('sk-stored')
+    expect(await settings.setApiKey('')).toEqual({ apiKeyConfigured: false, enabled: false })
+  })
+
+  it('persists the enabled toggle across instances', async () => {
+    const config = makeConfig('')
+    const appConfig = createAppConfig(config)
+    await createVisionSettings(config, appConfig).setEnabled(true)
+    expect(await createVisionSettings(config, appConfig).get()).toEqual({ apiKeyConfigured: false, enabled: true })
+  })
+})

--- a/src/vision/vision-settings.ts
+++ b/src/vision/vision-settings.ts
@@ -1,0 +1,39 @@
+import type { Config } from '../config'
+import type { createAppConfig } from '../persistence'
+
+export interface VisionSettingsState {
+  apiKeyConfigured: boolean
+  enabled: boolean
+}
+
+const API_KEY_CONFIG_KEY = 'vision.apiKey'
+const ENABLED_CONFIG_KEY = 'vision.enabled'
+
+export function createVisionSettings(config: Config, appConfig: ReturnType<typeof createAppConfig>) {
+  async function getApiKey(): Promise<string | null> {
+    if (config.vision.apiKey)
+      return config.vision.apiKey
+    const stored = await appConfig.get(API_KEY_CONFIG_KEY)
+    return stored?.trim() ? stored : null
+  }
+
+  async function get(): Promise<VisionSettingsState> {
+    const [apiKey, enabled] = await Promise.all([getApiKey(), appConfig.get(ENABLED_CONFIG_KEY)])
+    return { apiKeyConfigured: Boolean(apiKey), enabled: enabled === 'true' }
+  }
+
+  return {
+    getApiKey,
+    get,
+    async setApiKey(apiKey: string): Promise<VisionSettingsState> {
+      await appConfig.set(API_KEY_CONFIG_KEY, typeof apiKey === 'string' ? apiKey.trim() : '')
+      return get()
+    },
+    async setEnabled(enabled: boolean): Promise<VisionSettingsState> {
+      await appConfig.set(ENABLED_CONFIG_KEY, enabled ? 'true' : 'false')
+      return get()
+    },
+  }
+}
+
+export type VisionSettings = ReturnType<typeof createVisionSettings>

--- a/src/vision/vision.service.spec.ts
+++ b/src/vision/vision.service.spec.ts
@@ -1,0 +1,84 @@
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createVisionService } from './vision.service'
+
+const mockCreate = jest.fn()
+
+jest.mock('@anthropic-ai/sdk', () => {
+  class MockAPIError extends Error {
+    status: number
+    constructor(status: number, message: string) {
+      super(message)
+      this.status = status
+    }
+  }
+  const MockAnthropic = jest.fn().mockImplementation(() => ({
+    messages: { create: mockCreate },
+  })) as jest.Mock & { APIError: typeof MockAPIError, AuthenticationError: typeof MockAPIError }
+  MockAnthropic.APIError = MockAPIError
+  MockAnthropic.AuthenticationError = class extends MockAPIError {}
+  return { __esModule: true, default: MockAnthropic }
+})
+
+describe('createVisionService', () => {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'hibiki-vision-'))
+  const imagePath = join(tempRoot, 'map.png')
+  writeFileSync(imagePath, Buffer.from('fake-png-bytes'))
+
+  beforeEach(() => {
+    mockCreate.mockReset()
+  })
+
+  it('returns description and tags parsed from the model response', async () => {
+    mockCreate.mockResolvedValue({
+      stop_reason: 'end_turn',
+      content: [{ type: 'text', text: JSON.stringify({ description: 'A stormy coastline at dusk.', tags: ['stormy', ' coastline ', 'dusk', ''] }) }],
+    })
+    const service = createVisionService({ getApiKey: async () => 'sk-test' })
+    const result = await service.analyzeImageVibe(imagePath)
+    expect(result).toEqual({ description: 'A stormy coastline at dusk.', tags: ['stormy', 'coastline', 'dusk'] })
+  })
+
+  it('sends the image as base64 with the media type derived from the extension', async () => {
+    mockCreate.mockResolvedValue({
+      stop_reason: 'end_turn',
+      content: [{ type: 'text', text: JSON.stringify({ description: 'x', tags: ['a'] }) }],
+    })
+    const service = createVisionService({ getApiKey: async () => 'sk-test' })
+    await service.analyzeImageVibe(imagePath)
+    const params = mockCreate.mock.calls[0]![0]
+    const imageBlock = params.messages[0].content.find((b: { type: string }) => b.type === 'image')
+    expect(imageBlock.source).toEqual({
+      type: 'base64',
+      media_type: 'image/png',
+      data: Buffer.from('fake-png-bytes').toString('base64'),
+    })
+  })
+
+  it('rejects when the API call fails', async () => {
+    mockCreate.mockRejectedValue(new Error('boom'))
+    const service = createVisionService({ getApiKey: async () => 'sk-test' })
+    await expect(service.analyzeImageVibe(imagePath)).rejects.toThrow('boom')
+  })
+
+  it('rejects when the model refuses instead of returning an empty result', async () => {
+    mockCreate.mockResolvedValue({ stop_reason: 'refusal', content: [] })
+    const service = createVisionService({ getApiKey: async () => 'sk-test' })
+    await expect(service.analyzeImageVibe(imagePath)).rejects.toThrow(/declined/i)
+  })
+
+  it('rejects when no API key is configured without calling the API', async () => {
+    const service = createVisionService({ getApiKey: async () => null })
+    await expect(service.analyzeImageVibe(imagePath)).rejects.toThrow(/api key/i)
+    expect(mockCreate).not.toHaveBeenCalled()
+  })
+
+  it('rejects unsupported image formats without calling the API', async () => {
+    const bmpPath = join(tempRoot, 'map.bmp')
+    writeFileSync(bmpPath, 'x')
+    const service = createVisionService({ getApiKey: async () => 'sk-test' })
+    await expect(service.analyzeImageVibe(bmpPath)).rejects.toThrow(/unsupported/i)
+    expect(mockCreate).not.toHaveBeenCalled()
+  })
+})

--- a/src/vision/vision.service.ts
+++ b/src/vision/vision.service.ts
@@ -1,0 +1,112 @@
+import { readFile } from 'node:fs/promises'
+import { extname } from 'node:path'
+import Anthropic from '@anthropic-ai/sdk'
+
+export interface VibeAnalysis {
+  description: string
+  tags: string[]
+}
+
+export type VisionImageMediaType = 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp'
+
+export interface VisionImage {
+  data: Buffer
+  mediaType: VisionImageMediaType
+}
+
+/** A vision-capable model backend. Kept provider-agnostic so a second provider can slot in without touching the IPC surface. */
+export interface VisionProvider {
+  analyzeImage: (image: VisionImage) => Promise<VibeAnalysis>
+}
+
+const MEDIA_TYPES_BY_EXTENSION: Record<string, VisionImageMediaType> = {
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+}
+
+const CLAUDE_MODEL = 'claude-opus-5'
+
+const VIBE_PROMPT = `You are helping a tabletop game master pick background music and ambient soundscapes for the scene shown in this image.
+Describe the scene's atmosphere in one or two sentences, then list 5 to 10 short free-form tags capturing its mood, setting, weather, and time of day (for example "stormy", "candlelit tavern", "eerie forest", "night", "tense").
+Tags should be lowercase, one to three words each, and useful for matching against a sound library.`
+
+const VIBE_SCHEMA = {
+  type: 'object',
+  properties: {
+    description: { type: 'string', description: 'One or two sentences describing the atmosphere of the scene.' },
+    tags: {
+      type: 'array',
+      items: { type: 'string' },
+      description: 'Short lowercase tags for mood, setting, weather, and time of day.',
+    },
+  },
+  required: ['description', 'tags'],
+  additionalProperties: false,
+} as const
+
+function normalizeAnalysis(raw: unknown): VibeAnalysis {
+  const candidate = raw as Partial<VibeAnalysis> | null
+  const description = typeof candidate?.description === 'string' ? candidate.description.trim() : ''
+  const tags = Array.isArray(candidate?.tags)
+    ? candidate.tags.filter((t): t is string => typeof t === 'string').map(t => t.trim()).filter(t => t.length > 0)
+    : []
+  return { description, tags }
+}
+
+export function createClaudeVisionProvider(apiKey: string): VisionProvider {
+  const client = new Anthropic({ apiKey })
+  return {
+    async analyzeImage(image) {
+      const response = await client.messages.create({
+        model: CLAUDE_MODEL,
+        max_tokens: 1024,
+        output_config: { effort: 'low', format: { type: 'json_schema', schema: VIBE_SCHEMA } },
+        messages: [{
+          role: 'user',
+          content: [
+            { type: 'image', source: { type: 'base64', media_type: image.mediaType, data: image.data.toString('base64') } },
+            { type: 'text', text: VIBE_PROMPT },
+          ],
+        }],
+      })
+      if (response.stop_reason === 'refusal')
+        throw new Error('The vision model declined to analyze this image.')
+      const text = response.content
+        .filter((block): block is Anthropic.TextBlock => block.type === 'text')
+        .map(block => block.text)
+        .join('')
+      return normalizeAnalysis(JSON.parse(text))
+    },
+  }
+}
+
+export function resolveImageMediaType(imagePath: string): VisionImageMediaType | null {
+  return MEDIA_TYPES_BY_EXTENSION[extname(imagePath).toLowerCase()] ?? null
+}
+
+export interface VisionServiceOptions {
+  getApiKey: () => Promise<string | null>
+  createProvider?: (apiKey: string) => VisionProvider
+}
+
+export function createVisionService(options: VisionServiceOptions) {
+  const createProvider = options.createProvider ?? createClaudeVisionProvider
+
+  return {
+    async analyzeImageVibe(imagePath: string): Promise<VibeAnalysis> {
+      const apiKey = (await options.getApiKey())?.trim()
+      if (!apiKey)
+        throw new Error('Vision API key is not configured. Add it in Settings to use Vision to Vibe.')
+      const mediaType = resolveImageMediaType(imagePath)
+      if (!mediaType)
+        throw new Error('Unsupported image format. Use a PNG, JPEG, GIF, or WebP image.')
+      const data = await readFile(imagePath)
+      return createProvider(apiKey).analyzeImage({ data, mediaType })
+    },
+  }
+}
+
+export type VisionService = ReturnType<typeof createVisionService>


### PR DESCRIPTION
Closes #319

## What

Opt-in **Vision to Vibe**: drop a battle map / mood-board image into the scene editor, Claude describes the atmosphere and extracts Vibe Tags, and the GM's own **tagged** Music and Ambience are ranked and offered as one-click scene additions. It's a matching tool over the existing library — no audio generation, no new scene, no Effects, no auto-add.

Builds on the glossary/ADR from #334 (`CONTEXT.md`, `agent-docs/adr/0001-vision-to-vibe-matching.md`) and is rebased on top of the status pulses work (#336) — the Settings section reuses its toggle styles.

## How it works

**Sound Tags (backend)**
- `SoundFile.tags: string[]` — persisted in `sound-tags.json` (`src/sound/sound-tags.store.ts`, keyed `<category>/<id>`), merged into `list()` / `getFile()`, default `[]`, cleared on `remove()`. New `sounds.setTags(type, id, tags)` IPC.
- Additive: no migration for existing files.

**Vision (backend, `src/vision/`)**
- `vision.service.ts` — provider-agnostic `VisionProvider`; Claude implementation via `@anthropic-ai/sdk` (`claude-opus-5`, low effort, structured JSON output). Refusals surface as a rejected promise, not an empty result. Image is read from disk, sent once, never retained.
- `vibe-matching.ts` — pure `matchVibeTags()`: case-insensitive exact/substring overlap count, zero-overlap sounds excluded, top 5, ties → newest first. Music and Ambience scored independently.
- New `vision` IPC domain: `analyzeImageVibe(imagePath)` (refuses while the toggle is off) and `matchVibe(tags)`.
- Config: `getVision` / `setVisionApiKey` / `setVisionEnabled`. Key resolves `HIBIKI_VISION_API_KEY` first, then `app-config.json` (same precedence as `DISCORD_TOKEN`). Toggle defaults **off**.

**Frontend**
- **Settings** → new "Vision to Vibe" section: Anthropic key (save/remove), opt-in toggle (disabled until a key exists), explicit "sent to Anthropic's Claude API" disclosure.
- **Sound library** → inline per-row tag editing for Music and Ambience (chips + comma-separated input; Enter saves, Esc cancels).
- **Scene editor** → "✦ Vision to Vibe" button in the scene header (visible regardless of category), rendered only when key **and** toggle are set. `VisionToVibeDialog`: drop zone / "Choose image…", analysis summary (description + Vibe Tags), then separate Music / Ambience match lists with per-item **Add** (marked "Added" if already in the scene) and empty states that say plainly when the library isn't tagged yet.
- `preload.js` exposes `webUtils.getPathForFile` so drag-and-drop yields a real path.

## Tests

- Sound Tags at the sound-library boundary (real temp fs): default `[]`, persist + return from `list()`/`getFile()`, survive across instances, per-category scoping, cleared on remove, unknown id rejected.
- `matchVibeTags` exhaustively (exact, substring/case, zero-overlap excluded, empty tags never match, cap 5, custom limit, tie-break, one point per vibe tag).
- Vision service with the SDK mocked at the module boundary (happy path, base64/media-type, API error → reject, refusal → reject, no key / unsupported format → reject without calling the API).
- Frontend: `api/vision.ts` + config/sounds wrappers (Vitest, mocked `invoke`), Settings section, `SoundListManage` tag editing, `VisionToVibeDialog`, and `SceneView` gating (hidden for key-only, toggle-only, neither, or config error; shown + opens dialog for both).

`pnpm lint` ✓ · `pnpm test` ✓ (73 backend / 214 frontend) · `pnpm build` ✓

## Notes for review

- The spec's parenthetical says "config first, env fallback" for the key, but the actual Discord token code (`discord-client.ts`) is env-first → stored fallback, so I mirrored the code. Trivial to flip if you'd rather the stored key win.
- Model is `claude-opus-5` behind the `VisionProvider` seam; #335 (more providers) can add implementations without touching the IPC shape.
- I did **not** wire server-side refusal fallbacks (beta header) — a refusal simply surfaces as an error in the dialog. Easy to add later if it ever bites.
- Out of scope per the spec: generative audio, Effects matching, auto-tagging, saving the source image alongside the scene, additional providers (#335).
